### PR TITLE
Ensure SQLite path works on Apache and document server requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Interfaz web sencilla en PHP para realizar llamadas mediante la API de Siptize.
 
+## Requisitos
+
+- Servidor web Apache con PHP y las extensiones `PDO` y `cURL` habilitadas.
+- Permisos de escritura en el directorio donde se aloja el archivo para crear `calls.db`.
+
 ## Uso
 
 1. Abra `index.php` en su servidor web.

--- a/index.php
+++ b/index.php
@@ -2,8 +2,9 @@
 // Simple web interface to initiate calls via Siptize API
 // Stores extension and dialed number in a SQLite database
 
-// Connect to SQLite database
-$pdo = new PDO('sqlite:calls.db');
+// Connect to SQLite database using an absolute path so it works under Apache
+$dbPath = __DIR__ . '/calls.db';
+$pdo = new PDO('sqlite:' . $dbPath);
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 // Create table if it doesn't exist


### PR DESCRIPTION
## Summary
- use absolute path for SQLite database so index.php works reliably under Apache
- document Apache/PHP requirements and write permissions in README

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68bec6e632c0832eb68e0666d9e46668