### PR TITLE
Switch to MySQL database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-calls.db

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ Interfaz web sencilla en PHP para realizar llamadas mediante la API de Siptize.
 
 ## Requisitos
 
-- Servidor web Apache con PHP y las extensiones `PDO` y `cURL` habilitadas.
-- Permisos de escritura en el directorio donde se aloja el archivo para crear `calls.db`.
+- Servidor web Apache con PHP y las extensiones `PDO`, `PDO_MySQL` y `cURL` habilitadas.
+- Base de datos MySQL disponible.
 
 ## Uso
 
 1. Abra `index.php` en su servidor web.
 2. Ingrese la extensión y el código a marcar.
-3. El sistema realizará la llamada a través de `https://vpbx.me/api/originatecall/{extension}/{number}?timeout=20&autoAnswer=true` y almacenará la información en `calls.db`.
+3. Configure las variables de entorno `DB_HOST`, `DB_NAME`, `DB_USER` y `DB_PASS` o edite el archivo `index.php` con sus credenciales de MySQL.
+4. El sistema realizará la llamada a través de `https://vpbx.me/api/originatecall/{extension}/{number}?timeout=20&autoAnswer=true` y almacenará la información en la tabla `calls` de MySQL.
 
 El historial de llamadas se muestra en la misma página.

--- a/index.php
+++ b/index.php
@@ -1,19 +1,30 @@
 <?php
 // Simple web interface to initiate calls via Siptize API
-// Stores extension and dialed number in a SQLite database
+// Stores extension and dialed number in a MySQL database
 
-// Connect to SQLite database using an absolute path so it works under Apache
-$dbPath = __DIR__ . '/calls.db';
-$pdo = new PDO('sqlite:' . $dbPath);
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+// Connect to MySQL database using environment variables or defaults
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME') ?: 'calls';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: '';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+$pdo = new PDO($dsn, $user, $pass, $options);
 
 // Create table if it doesn't exist
 $pdo->exec('CREATE TABLE IF NOT EXISTS calls (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    extension TEXT NOT NULL,
-    number TEXT NOT NULL,
-    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-)');
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    extension VARCHAR(255) NOT NULL,
+    number VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 
 $message = '';
 


### PR DESCRIPTION
## Summary
- Replace SQLite storage with MySQL using PDO and environment-configured credentials
- Update documentation to reflect MySQL requirements and setup
- Remove obsolete SQLite database ignore rule

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68bec888fe40832e84413a8e72c9272d