### PR TITLE
Add call scheduling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ Interfaz web sencilla en PHP para realizar llamadas mediante la API de Siptize.
 ## Uso
 
 1. Abra `index.php` en su servidor web.
-2. Ingrese la extensión y el código a marcar.
-3. Configure las variables de entorno `DB_HOST`, `DB_NAME`, `DB_USER` y `DB_PASS` o edite el archivo `index.php` con sus credenciales de MySQL.
-4. El sistema realizará la llamada a través de `https://vpbx.me/api/originatecall/{extension}/{number}?timeout=20&autoAnswer=true` y almacenará la información en la tabla `calls` de MySQL.
+2. Ingrese la extensión y el código a marcar para realizar una llamada inmediata.
+3. Para programar una llamada futura, complete el formulario **Programar llamada** indicando la fecha y hora.
+4. Configure las variables de entorno `DB_HOST`, `DB_NAME`, `DB_USER` y `DB_PASS` o edite el archivo `index.php` con sus credenciales de MySQL.
+5. El sistema realizará la llamada a través de `https://vpbx.me/api/originatecall/{extension}/{number}?timeout=20&autoAnswer=true` y almacenará la información en la tabla `calls` de MySQL.
 
-El historial de llamadas se muestra en la misma página.
+Las llamadas programadas se guardan en la tabla `scheduled_calls`. Ejecute periódicamente `run_scheduled.php` (por ejemplo, con `cron`) para que las llamadas pendientes se realicen en la fecha y hora indicadas.
+
+El historial y las llamadas programadas se muestran en la misma página.

--- a/index.php
+++ b/index.php
@@ -1,6 +1,7 @@
 <?php
 // Simple web interface to initiate calls via Siptize API
 // Stores extension and dialed number in a MySQL database
+// Allows scheduling calls for future execution
 
 // Connect to MySQL database using environment variables or defaults
 $host = getenv('DB_HOST') ?: 'localhost';
@@ -26,29 +27,50 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS calls (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 
+$pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    extension VARCHAR(255) NOT NULL,
+    number VARCHAR(255) NOT NULL,
+    scheduled_at DATETIME NOT NULL,
+    executed_at DATETIME DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
     $extension = trim($_POST['extension'] ?? '');
     $number = trim($_POST['number'] ?? '');
 
-    if ($extension !== '' && $number !== '') {
-        // Call Siptize API
-        $url = "https://vpbx.me/api/originatecall/" . urlencode($extension) . "/" . urlencode($number) . "?timeout=20&autoAnswer=true";
+    if ($action === 'call_now') {
+        if ($extension !== '' && $number !== '') {
+            // Call Siptize API
+            $url = "https://vpbx.me/api/originatecall/" . urlencode($extension) . "/" . urlencode($number) . "?timeout=20&autoAnswer=true";
 
-        $ch = curl_init($url);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        $response = curl_exec($ch);
-        $error = curl_error($ch);
-        curl_close($ch);
+            $ch = curl_init($url);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            $response = curl_exec($ch);
+            $error = curl_error($ch);
+            curl_close($ch);
 
-        // Store call data
-        $stmt = $pdo->prepare('INSERT INTO calls(extension, number) VALUES (:extension, :number)');
-        $stmt->execute([':extension' => $extension, ':number' => $number]);
+            // Store call data
+            $stmt = $pdo->prepare('INSERT INTO calls(extension, number) VALUES (:extension, :number)');
+            $stmt->execute([':extension' => $extension, ':number' => $number]);
 
-        $message = $error ? "Error: $error" : "API response: $response";
-    } else {
-        $message = 'Both extension and code are required.';
+            $message = $error ? "Error: $error" : "API response: $response";
+        } else {
+            $message = 'Both extension and code are required.';
+        }
+    } elseif ($action === 'schedule') {
+        $scheduled_at = trim($_POST['scheduled_at'] ?? '');
+        if ($extension !== '' && $number !== '' && $scheduled_at !== '') {
+            $stmt = $pdo->prepare('INSERT INTO scheduled_calls(extension, number, scheduled_at) VALUES (:extension, :number, :scheduled_at)');
+            $stmt->execute([':extension' => $extension, ':number' => $number, ':scheduled_at' => $scheduled_at]);
+            $message = 'Call scheduled.';
+        } else {
+            $message = 'All fields are required to schedule a call.';
+        }
     }
 }
 ?>
@@ -63,7 +85,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <?php if ($message): ?>
         <p><?= htmlspecialchars($message) ?></p>
     <?php endif; ?>
+
+    <h2>Llamada inmediata</h2>
     <form method="post">
+        <input type="hidden" name="action" value="call_now">
         <label>
             Extensión:
             <input type="text" name="extension" required>
@@ -77,12 +102,43 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <button type="submit">Llamar</button>
     </form>
 
+    <h2>Programar llamada</h2>
+    <form method="post">
+        <input type="hidden" name="action" value="schedule">
+        <label>
+            Extensión:
+            <input type="text" name="extension" required>
+        </label>
+        <br>
+        <label>
+            Código:
+            <input type="text" name="number" required>
+        </label>
+        <br>
+        <label>
+            Fecha y hora:
+            <input type="datetime-local" name="scheduled_at" required>
+        </label>
+        <br>
+        <button type="submit">Programar</button>
+    </form>
+
     <h2>Historial</h2>
     <table border="1">
         <tr><th>Extensión</th><th>Código</th><th>Fecha</th></tr>
         <?php
         foreach ($pdo->query('SELECT extension, number, created_at FROM calls ORDER BY id DESC') as $row) {
             echo '<tr><td>' . htmlspecialchars($row['extension']) . '</td><td>' . htmlspecialchars($row['number']) . '</td><td>' . htmlspecialchars($row['created_at']) . '</td></tr>';
+        }
+        ?>
+    </table>
+
+    <h2>Llamadas programadas</h2>
+    <table border="1">
+        <tr><th>Extensión</th><th>Código</th><th>Programada</th><th>Ejecutada</th></tr>
+        <?php
+        foreach ($pdo->query('SELECT extension, number, scheduled_at, executed_at FROM scheduled_calls ORDER BY id DESC') as $row) {
+            echo '<tr><td>' . htmlspecialchars($row['extension']) . '</td><td>' . htmlspecialchars($row['number']) . '</td><td>' . htmlspecialchars($row['scheduled_at']) . '</td><td>' . htmlspecialchars($row['executed_at'] ?? '-') . '</td></tr>';
         }
         ?>
     </table>

--- a/run_scheduled.php
+++ b/run_scheduled.php
@@ -1,0 +1,50 @@
+<?php
+// Execute scheduled calls due at the current time
+
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME') ?: 'calls';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: '';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+$pdo = new PDO($dsn, $user, $pass, $options);
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    extension VARCHAR(255) NOT NULL,
+    number VARCHAR(255) NOT NULL,
+    scheduled_at DATETIME NOT NULL,
+    executed_at DATETIME DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+$stmt = $pdo->prepare('SELECT id, extension, number FROM scheduled_calls WHERE executed_at IS NULL AND scheduled_at <= NOW()');
+$stmt->execute();
+$calls = $stmt->fetchAll();
+
+foreach ($calls as $call) {
+    $url = "https://vpbx.me/api/originatecall/" . urlencode($call['extension']) . "/" . urlencode($call['number']) . "?timeout=20&autoAnswer=true";
+
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $response = curl_exec($ch);
+    $error = curl_error($ch);
+    curl_close($ch);
+
+    $update = $pdo->prepare('UPDATE scheduled_calls SET executed_at = NOW() WHERE id = :id');
+    $update->execute([':id' => $call['id']]);
+
+    if ($error) {
+        echo "Error for {$call['id']}: $error\n";
+    } else {
+        echo "Executed {$call['id']}: $response\n";
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow scheduling calls by storing them in new `scheduled_calls` table
- add `run_scheduled.php` script that executes pending scheduled calls
- document how to schedule and run calls

## Testing
- `php -l index.php`
- `php -l run_scheduled.php`


------
https://chatgpt.com/codex/tasks/task_e_68becc08442c832e959b53f1f3cbebc7