### PR TITLE
Improve UI with Bootstrap and multi-date calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MultivoiceAutoComportamiento
 
-Interfaz web sencilla en PHP para realizar llamadas mediante la API de Siptize.
+Interfaz web en PHP para realizar llamadas mediante la API de Siptize.
 
 ## Requisitos
 
@@ -9,12 +9,10 @@ Interfaz web sencilla en PHP para realizar llamadas mediante la API de Siptize.
 
 ## Uso
 
-1. Abra `index.php` en su servidor web.
-2. Ingrese la extensión y el código a marcar para realizar una llamada inmediata.
-3. Para programar una llamada futura, complete el formulario **Programar llamada** indicando la fecha y hora.
-4. Configure las variables de entorno `DB_HOST`, `DB_NAME`, `DB_USER` y `DB_PASS` o edite el archivo `index.php` con sus credenciales de MySQL.
-5. El sistema realizará la llamada a través de `https://vpbx.me/api/originatecall/{extension}/{number}?timeout=20&autoAnswer=true` y almacenará la información en la tabla `calls` de MySQL.
+1. Abra `config.php` para realizar llamadas inmediatas o configurar múltiples fechas para cada combinación de extensión y código.
+2. Seleccione las fechas desde el calendario (puede marcar varias) y guárdelas; los días seleccionados se almacenan en la base de datos y aparecerán resaltados al volver a abrir la página.
+3. El historial de llamadas y de fechas programadas se visualiza en `index.php`.
+4. Configure las variables de entorno `DB_HOST`, `DB_NAME`, `DB_USER` y `DB_PASS` o edite los archivos PHP con sus credenciales de MySQL.
+5. Ejecute periódicamente `run_scheduled.php` (por ejemplo, con `cron`) para que las llamadas pendientes se realicen en la fecha indicada.
 
-Las llamadas programadas se guardan en la tabla `scheduled_calls`. Ejecute periódicamente `run_scheduled.php` (por ejemplo, con `cron`) para que las llamadas pendientes se realicen en la fecha y hora indicadas.
-
-El historial y las llamadas programadas se muestran en la misma página.
+La interfaz utiliza Bootstrap para un diseño más amigable y Flatpickr para el calendario de selección múltiple.

--- a/config.php
+++ b/config.php
@@ -1,0 +1,164 @@
+<?php
+// Configuration page with multi-date calendar using Bootstrap and Flatpickr
+
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME') ?: 'calls';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: '';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+$pdo = new PDO($dsn, $user, $pass, $options);
+
+// Ensure required tables exist
+$pdo->exec('CREATE TABLE IF NOT EXISTS calls (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    extension VARCHAR(255) NOT NULL,
+    number VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    extension VARCHAR(255) NOT NULL,
+    number VARCHAR(255) NOT NULL,
+    scheduled_at DATETIME NOT NULL,
+    executed_at DATETIME DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+$message = '';
+$extension = trim($_POST['extension'] ?? '');
+$number = trim($_POST['number'] ?? '');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'call_now') {
+        if ($extension !== '' && $number !== '') {
+            $url = "https://vpbx.me/api/originatecall/" . urlencode($extension) . "/" . urlencode($number) . "?timeout=20&autoAnswer=true";
+            $ch = curl_init($url);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            $response = curl_exec($ch);
+            $error = curl_error($ch);
+            curl_close($ch);
+
+            $stmt = $pdo->prepare('INSERT INTO calls(extension, number) VALUES (:extension, :number)');
+            $stmt->execute([':extension' => $extension, ':number' => $number]);
+
+            $message = $error ? "Error: $error" : "API response: $response";
+        } else {
+            $message = 'Both extension and code are required.';
+        }
+    } elseif ($action === 'save_dates') {
+        $dates = $_POST['dates'] ?? '';
+        if ($extension !== '' && $number !== '' && $dates !== '') {
+            $pdo->prepare('DELETE FROM scheduled_calls WHERE extension = :extension AND number = :number AND executed_at IS NULL')
+                ->execute([':extension' => $extension, ':number' => $number]);
+
+            $dateArray = array_filter(array_map('trim', explode(',', $dates)));
+            $insert = $pdo->prepare('INSERT INTO scheduled_calls(extension, number, scheduled_at) VALUES (:extension, :number, :scheduled_at)');
+            foreach ($dateArray as $d) {
+                $insert->execute([
+                    ':extension' => $extension,
+                    ':number' => $number,
+                    ':scheduled_at' => $d . ' 00:00:00'
+                ]);
+            }
+            $message = 'Fechas actualizadas.';
+        } else {
+            $message = 'Todos los campos son obligatorios.';
+        }
+    }
+}
+
+$selectedDates = [];
+if ($extension !== '' && $number !== '') {
+    $stmt = $pdo->prepare('SELECT DATE(scheduled_at) AS d FROM scheduled_calls WHERE extension = :extension AND number = :number AND executed_at IS NULL');
+    $stmt->execute([':extension' => $extension, ':number' => $number]);
+    $selectedDates = array_column($stmt->fetchAll(), 'd');
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Configuración</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#">Marcación Siptize</a>
+        <div class="navbar-nav">
+            <a class="nav-link" href="index.php">Historial</a>
+            <a class="nav-link active" href="config.php">Configuración</a>
+        </div>
+    </div>
+</nav>
+<div class="container">
+    <?php if ($message): ?>
+        <div class="alert alert-info"><?= htmlspecialchars($message) ?></div>
+    <?php endif; ?>
+
+    <h2>Llamada inmediata</h2>
+    <form method="post" class="mb-5">
+        <input type="hidden" name="action" value="call_now">
+        <div class="row mb-3">
+            <div class="col">
+                <label for="extension" class="form-label">Extensión</label>
+                <input type="text" class="form-control" name="extension" id="extension" value="<?= htmlspecialchars($extension) ?>" required>
+            </div>
+            <div class="col">
+                <label for="number" class="form-label">Código</label>
+                <input type="text" class="form-control" name="number" id="number" value="<?= htmlspecialchars($number) ?>" required>
+            </div>
+        </div>
+        <button type="submit" class="btn btn-primary">Llamar</button>
+    </form>
+
+    <h2>Configurar calendario</h2>
+    <form method="post">
+        <input type="hidden" name="action" value="save_dates">
+        <div class="row mb-3">
+            <div class="col">
+                <label for="extension2" class="form-label">Extensión</label>
+                <input type="text" class="form-control" name="extension" id="extension2" value="<?= htmlspecialchars($extension) ?>" required>
+            </div>
+            <div class="col">
+                <label for="number2" class="form-label">Código</label>
+                <input type="text" class="form-control" name="number" id="number2" value="<?= htmlspecialchars($number) ?>" required>
+            </div>
+        </div>
+        <div class="mb-3">
+            <label for="datePicker" class="form-label">Fechas</label>
+            <input type="text" id="datePicker" class="form-control">
+            <input type="hidden" name="dates" id="dates">
+        </div>
+        <button type="submit" class="btn btn-success">Guardar fechas</button>
+    </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script>
+var selectedDates = <?php echo json_encode($selectedDates); ?>;
+var fp = flatpickr("#datePicker", {
+    mode: "multiple",
+    dateFormat: "Y-m-d",
+    defaultDate: selectedDates,
+    onChange: function(selDates, dateStr, instance) {
+        document.getElementById('dates').value = selDates.map(function(d){return instance.formatDate(d, "Y-m-d");}).join(',');
+    }
+});
+// Initialize hidden input with default dates
+ document.getElementById('dates').value = selectedDates.join(',');
+</script>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -1,9 +1,6 @@
 <?php
-// Simple web interface to initiate calls via Siptize API
-// Stores extension and dialed number in a MySQL database
-// Allows scheduling calls for future execution
+// History page styled with Bootstrap
 
-// Connect to MySQL database using environment variables or defaults
 $host = getenv('DB_HOST') ?: 'localhost';
 $db   = getenv('DB_NAME') ?: 'calls';
 $user = getenv('DB_USER') ?: 'root';
@@ -19,7 +16,6 @@ $options = [
 
 $pdo = new PDO($dsn, $user, $pass, $options);
 
-// Create table if it doesn't exist
 $pdo->exec('CREATE TABLE IF NOT EXISTS calls (
     id INT AUTO_INCREMENT PRIMARY KEY,
     extension VARCHAR(255) NOT NULL,
@@ -35,112 +31,54 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     executed_at DATETIME DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
-
-$message = '';
-
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $action = $_POST['action'] ?? '';
-    $extension = trim($_POST['extension'] ?? '');
-    $number = trim($_POST['number'] ?? '');
-
-    if ($action === 'call_now') {
-        if ($extension !== '' && $number !== '') {
-            // Call Siptize API
-            $url = "https://vpbx.me/api/originatecall/" . urlencode($extension) . "/" . urlencode($number) . "?timeout=20&autoAnswer=true";
-
-            $ch = curl_init($url);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            $response = curl_exec($ch);
-            $error = curl_error($ch);
-            curl_close($ch);
-
-            // Store call data
-            $stmt = $pdo->prepare('INSERT INTO calls(extension, number) VALUES (:extension, :number)');
-            $stmt->execute([':extension' => $extension, ':number' => $number]);
-
-            $message = $error ? "Error: $error" : "API response: $response";
-        } else {
-            $message = 'Both extension and code are required.';
-        }
-    } elseif ($action === 'schedule') {
-        $scheduled_at = trim($_POST['scheduled_at'] ?? '');
-        if ($extension !== '' && $number !== '' && $scheduled_at !== '') {
-            $stmt = $pdo->prepare('INSERT INTO scheduled_calls(extension, number, scheduled_at) VALUES (:extension, :number, :scheduled_at)');
-            $stmt->execute([':extension' => $extension, ':number' => $number, ':scheduled_at' => $scheduled_at]);
-            $message = 'Call scheduled.';
-        } else {
-            $message = 'All fields are required to schedule a call.';
-        }
-    }
-}
 ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Marcación Siptize</title>
+    <title>Historial</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-    <h1>Marcación Siptize</h1>
-    <?php if ($message): ?>
-        <p><?= htmlspecialchars($message) ?></p>
-    <?php endif; ?>
-
-    <h2>Llamada inmediata</h2>
-    <form method="post">
-        <input type="hidden" name="action" value="call_now">
-        <label>
-            Extensión:
-            <input type="text" name="extension" required>
-        </label>
-        <br>
-        <label>
-            Código:
-            <input type="text" name="number" required>
-        </label>
-        <br>
-        <button type="submit">Llamar</button>
-    </form>
-
-    <h2>Programar llamada</h2>
-    <form method="post">
-        <input type="hidden" name="action" value="schedule">
-        <label>
-            Extensión:
-            <input type="text" name="extension" required>
-        </label>
-        <br>
-        <label>
-            Código:
-            <input type="text" name="number" required>
-        </label>
-        <br>
-        <label>
-            Fecha y hora:
-            <input type="datetime-local" name="scheduled_at" required>
-        </label>
-        <br>
-        <button type="submit">Programar</button>
-    </form>
-
-    <h2>Historial</h2>
-    <table border="1">
-        <tr><th>Extensión</th><th>Código</th><th>Fecha</th></tr>
-        <?php
-        foreach ($pdo->query('SELECT extension, number, created_at FROM calls ORDER BY id DESC') as $row) {
-            echo '<tr><td>' . htmlspecialchars($row['extension']) . '</td><td>' . htmlspecialchars($row['number']) . '</td><td>' . htmlspecialchars($row['created_at']) . '</td></tr>';
-        }
-        ?>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#">Marcación Siptize</a>
+        <div class="navbar-nav">
+            <a class="nav-link active" href="index.php">Historial</a>
+            <a class="nav-link" href="config.php">Configuración</a>
+        </div>
+    </div>
+</nav>
+<div class="container">
+    <h2>Llamadas realizadas</h2>
+    <table class="table table-striped">
+        <thead><tr><th>Extensión</th><th>Código</th><th>Fecha</th></tr></thead>
+        <tbody>
+        <?php foreach ($pdo->query('SELECT extension, number, created_at FROM calls ORDER BY id DESC') as $row): ?>
+            <tr>
+                <td><?= htmlspecialchars($row['extension']) ?></td>
+                <td><?= htmlspecialchars($row['number']) ?></td>
+                <td><?= htmlspecialchars($row['created_at']) ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
     </table>
 
     <h2>Llamadas programadas</h2>
-    <table border="1">
-        <tr><th>Extensión</th><th>Código</th><th>Programada</th><th>Ejecutada</th></tr>
-        <?php
-        foreach ($pdo->query('SELECT extension, number, scheduled_at, executed_at FROM scheduled_calls ORDER BY id DESC') as $row) {
-            echo '<tr><td>' . htmlspecialchars($row['extension']) . '</td><td>' . htmlspecialchars($row['number']) . '</td><td>' . htmlspecialchars($row['scheduled_at']) . '</td><td>' . htmlspecialchars($row['executed_at'] ?? '-') . '</td></tr>';
-        }
-        ?>
+    <table class="table table-striped">
+        <thead><tr><th>Extensión</th><th>Código</th><th>Programada</th><th>Ejecutada</th></tr></thead>
+        <tbody>
+        <?php foreach ($pdo->query('SELECT extension, number, scheduled_at, executed_at FROM scheduled_calls ORDER BY id DESC') as $row): ?>
+            <tr>
+                <td><?= htmlspecialchars($row['extension']) ?></td>
+                <td><?= htmlspecialchars($row['number']) ?></td>
+                <td><?= htmlspecialchars($row['scheduled_at']) ?></td>
+                <td><?= htmlspecialchars($row['executed_at'] ?? '-') ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
     </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace old single-page interface with Bootstrap-styled history page
- Add configuration page with multi-date calendar storing selections per extension/number
- Document new workflow and libraries in README

## Testing
- `php -l index.php`
- `php -l config.php`
- `php -l run_scheduled.php`


------
https://chatgpt.com/codex/tasks/task_e_68bed3475c00832e85fb228411845179