### PR TITLE
Allow editing of scheduled dates

### DIFF
--- a/config.php
+++ b/config.php
@@ -41,8 +41,8 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS settings (
 $apiKey = $pdo->query('SELECT api_key FROM settings WHERE id = 1')->fetchColumn() ?: '';
 
 $message = '';
-$extension = trim($_POST['extension'] ?? '');
-$number = trim($_POST['number'] ?? '');
+$extension = trim($_POST['extension'] ?? $_GET['extension'] ?? '');
+$number = trim($_POST['number'] ?? $_GET['number'] ?? '');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';

--- a/index.php
+++ b/index.php
@@ -66,7 +66,7 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
 
     <h2>Llamadas programadas</h2>
     <table class="table table-striped">
-        <thead><tr><th>Extensión</th><th>Código</th><th>Programada</th><th>Ejecutada</th></tr></thead>
+        <thead><tr><th>Extensión</th><th>Código</th><th>Programada</th><th>Ejecutada</th><th>Editar</th></tr></thead>
         <tbody>
         <?php foreach ($pdo->query('SELECT extension, number, scheduled_at, executed_at FROM scheduled_calls ORDER BY id DESC') as $row): ?>
             <tr>
@@ -74,6 +74,7 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
                 <td><?= htmlspecialchars($row['number']) ?></td>
                 <td><?= htmlspecialchars($row['scheduled_at']) ?></td>
                 <td><?= htmlspecialchars($row['executed_at'] ?? '-') ?></td>
+                <td><a class="btn btn-sm btn-primary" href="config.php?extension=<?= urlencode($row['extension']) ?>&number=<?= urlencode($row['number']) ?>">Editar</a></td>
             </tr>
         <?php endforeach; ?>
         </tbody>


### PR DESCRIPTION
## Summary
- Allow configuration form to prefill extension and code using query parameters so calendars can be reopened for editing
- Display calendar with previously saved dates and provide edit links from scheduled calls list

## Testing
- `php -l index.php`
- `php -l config.php`


------
https://chatgpt.com/codex/tasks/task_e_68bed7d77b1c832eaab7f906dce31f74