### PR TITLE
Add code management and separate calendar scheduling

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -1,0 +1,158 @@
+<?php
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME') ?: 'multivoice';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: 'terminal';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+$pdo = new PDO($dsn, $user, $pass, $options);
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    extension VARCHAR(255) NOT NULL,
+    number VARCHAR(255) NOT NULL,
+    scheduled_at DATETIME NOT NULL,
+    executed_at DATETIME DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS settings (
+    id INT PRIMARY KEY,
+    api_key VARCHAR(255) NOT NULL,
+    default_extension VARCHAR(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+try {
+    $pdo->exec('ALTER TABLE settings ADD COLUMN default_extension VARCHAR(255) DEFAULT NULL');
+} catch (PDOException $e) {
+}
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS codes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    code VARCHAR(255) NOT NULL UNIQUE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+$settings = $pdo->query('SELECT default_extension FROM settings WHERE id = 1')->fetch() ?: [];
+$defaultExtension = $settings['default_extension'] ?? '';
+
+$codes = $pdo->query('SELECT name, code FROM codes ORDER BY name')->fetchAll();
+
+$message = '';
+$extension = trim($_POST['extension'] ?? $_GET['extension'] ?? $defaultExtension);
+$number = trim($_POST['number'] ?? $_GET['number'] ?? ($codes[0]['code'] ?? ''));
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    if ($action === 'save_dates') {
+        $dates = $_POST['dates'] ?? '';
+        if ($extension !== '' && $number !== '') {
+            $pdo->prepare('DELETE FROM scheduled_calls WHERE extension = :extension AND number = :number AND executed_at IS NULL')
+                ->execute([':extension' => $extension, ':number' => $number]);
+
+            if ($dates !== '') {
+                $dateArray = array_filter(array_map('trim', explode(',', $dates)));
+                $insert = $pdo->prepare('INSERT INTO scheduled_calls(extension, number, scheduled_at) VALUES (:extension, :number, :scheduled_at)');
+                foreach ($dateArray as $d) {
+                    $insert->execute([
+                        ':extension' => $extension,
+                        ':number' => $number,
+                        ':scheduled_at' => $d . ' 00:00:00'
+                    ]);
+                }
+                $message = 'Fechas actualizadas.';
+            } else {
+                $message = 'Fechas eliminadas.';
+            }
+        } else {
+            $message = 'Todos los campos son obligatorios.';
+        }
+    }
+}
+
+$selectedDates = [];
+if ($extension !== '' && $number !== '') {
+    $stmt = $pdo->prepare('SELECT DATE(scheduled_at) AS d FROM scheduled_calls WHERE extension = :extension AND number = :number AND executed_at IS NULL');
+    $stmt->execute([':extension' => $extension, ':number' => $number]);
+    $selectedDates = array_column($stmt->fetchAll(), 'd');
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Calendario</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#">Marcación Siptize</a>
+        <div class="navbar-nav">
+            <a class="nav-link" href="index.php">Historial</a>
+            <a class="nav-link" href="config.php">Configuración</a>
+            <a class="nav-link active" href="calendar.php">Calendario</a>
+        </div>
+    </div>
+</nav>
+<div class="container">
+<?php if ($message): ?>
+    <div class="alert alert-info"><?= htmlspecialchars($message) ?></div>
+<?php endif; ?>
+<?php if (!$codes): ?>
+    <p>No hay códigos guardados. Agregue uno en Configuración.</p>
+<?php else: ?>
+    <h2>Configurar calendario</h2>
+    <form method="post">
+        <input type="hidden" name="action" value="save_dates">
+        <div class="row mb-3">
+            <div class="col">
+                <label for="extension" class="form-label">Extensión</label>
+                <input type="text" class="form-control" name="extension" id="extension" value="<?= htmlspecialchars($extension) ?>" required>
+            </div>
+            <div class="col">
+                <label for="number" class="form-label">Código</label>
+                <select class="form-select" name="number" id="number" required>
+                    <?php foreach ($codes as $code): ?>
+                        <option value="<?= htmlspecialchars($code['code']) ?>" <?= $code['code'] === $number ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($code['name']) ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+        </div>
+        <div class="mb-3">
+            <label for="datePicker" class="form-label">Fechas</label>
+            <input type="text" id="datePicker" class="form-control">
+            <input type="hidden" name="dates" id="dates">
+        </div>
+        <button type="submit" class="btn btn-success">Guardar fechas</button>
+    </form>
+<?php endif; ?>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/es.js"></script>
+<script>
+var selectedDates = <?php echo json_encode($selectedDates); ?>;
+flatpickr("#datePicker", {
+    locale: "es",
+    mode: "multiple",
+    dateFormat: "Y-m-d",
+    defaultDate: selectedDates,
+    onChange: function(selDates, dateStr, instance) {
+        document.getElementById('dates').value = selDates.map(function(d){return instance.formatDate(d, 'Y-m-d');}).join(',');
+    }
+});
+document.getElementById('dates').value = selectedDates.join(',');
+</script>
+</body>
+</html>
+

--- a/config.php
+++ b/config.php
@@ -35,28 +35,40 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS settings (
     id INT PRIMARY KEY,
-    api_key VARCHAR(255) NOT NULL
+    api_key VARCHAR(255) NOT NULL,
+    default_extension VARCHAR(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+try {
+    $pdo->exec('ALTER TABLE settings ADD COLUMN default_extension VARCHAR(255) DEFAULT NULL');
+} catch (PDOException $e) {
+    // Column may already exist
+}
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS codes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    code VARCHAR(255) NOT NULL UNIQUE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 
-$apiKey = $pdo->query('SELECT api_key FROM settings WHERE id = 1')->fetchColumn() ?: '';
+$settings = $pdo->query('SELECT api_key, default_extension FROM settings WHERE id = 1')->fetch() ?: [];
+$apiKey = $settings['api_key'] ?? '';
+$defaultExtension = $settings['default_extension'] ?? '';
 
 $message = '';
-$extension = trim($_POST['extension'] ?? $_GET['extension'] ?? '');
+$extension = trim($_POST['extension'] ?? $_GET['extension'] ?? $defaultExtension);
 $number = trim($_POST['number'] ?? $_GET['number'] ?? '');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';
 
-    if ($action === 'save_api_key') {
+    if ($action === 'save_settings') {
         $newKey = trim($_POST['api_key'] ?? '');
-        if ($newKey !== '') {
-            $stmt = $pdo->prepare('REPLACE INTO settings (id, api_key) VALUES (1, :api_key)');
-            $stmt->execute([':api_key' => $newKey]);
-            $apiKey = $newKey;
-            $message = 'API key actualizada.';
-        } else {
-            $message = 'La API key es obligatoria.';
-        }
+        $newDefault = trim($_POST['default_extension'] ?? '');
+        $stmt = $pdo->prepare('REPLACE INTO settings (id, api_key, default_extension) VALUES (1, :api_key, :default_extension)');
+        $stmt->execute([':api_key' => $newKey, ':default_extension' => $newDefault]);
+        $apiKey = $newKey;
+        $defaultExtension = $newDefault;
+        $message = 'Configuración actualizada.';
     } elseif ($action === 'call_now') {
         if ($apiKey === '') {
             $message = 'API key no configurada.';
@@ -79,38 +91,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } else {
             $message = 'Both extension and code are required.';
         }
-    } elseif ($action === 'save_dates') {
-        $dates = $_POST['dates'] ?? '';
-        if ($extension !== '' && $number !== '') {
-            $pdo->prepare('DELETE FROM scheduled_calls WHERE extension = :extension AND number = :number AND executed_at IS NULL')
-                ->execute([':extension' => $extension, ':number' => $number]);
-
-            if ($dates !== '') {
-                $dateArray = array_filter(array_map('trim', explode(',', $dates)));
-                $insert = $pdo->prepare('INSERT INTO scheduled_calls(extension, number, scheduled_at) VALUES (:extension, :number, :scheduled_at)');
-                foreach ($dateArray as $d) {
-                    $insert->execute([
-                        ':extension' => $extension,
-                        ':number' => $number,
-                        ':scheduled_at' => $d . ' 00:00:00'
-                    ]);
-                }
-                $message = 'Fechas actualizadas.';
-            } else {
-                $message = 'Fechas eliminadas.';
-            }
+    } elseif ($action === 'save_code') {
+        $codeName = trim($_POST['code_name'] ?? '');
+        $codeValue = trim($_POST['code_value'] ?? '');
+        if ($codeName !== '' && $codeValue !== '') {
+            $stmt = $pdo->prepare('INSERT INTO codes(name, code) VALUES (:name, :code) ON DUPLICATE KEY UPDATE name=VALUES(name)');
+            $stmt->execute([':name' => $codeName, ':code' => $codeValue]);
+            $message = 'Código guardado.';
         } else {
-            $message = 'Todos los campos son obligatorios.';
+            $message = 'Nombre y código son obligatorios.';
         }
     }
 }
 
-$selectedDates = [];
-if ($extension !== '' && $number !== '') {
-    $stmt = $pdo->prepare('SELECT DATE(scheduled_at) AS d FROM scheduled_calls WHERE extension = :extension AND number = :number AND executed_at IS NULL');
-    $stmt->execute([':extension' => $extension, ':number' => $number]);
-    $selectedDates = array_column($stmt->fetchAll(), 'd');
-}
+$codes = $pdo->query('SELECT name, code FROM codes ORDER BY name')->fetchAll();
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -118,7 +112,6 @@ if ($extension !== '' && $number !== '') {
     <meta charset="UTF-8">
     <title>Configuración</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
@@ -127,6 +120,7 @@ if ($extension !== '' && $number !== '') {
         <div class="navbar-nav">
             <a class="nav-link" href="index.php">Historial</a>
             <a class="nav-link active" href="config.php">Configuración</a>
+            <a class="nav-link" href="calendar.php">Calendario</a>
         </div>
     </div>
 </nav>
@@ -135,14 +129,18 @@ if ($extension !== '' && $number !== '') {
         <div class="alert alert-info"><?= htmlspecialchars($message) ?></div>
     <?php endif; ?>
 
-    <h2>API Key</h2>
+    <h2>Configuración general</h2>
     <form method="post" class="mb-5">
-        <input type="hidden" name="action" value="save_api_key">
+        <input type="hidden" name="action" value="save_settings">
         <div class="mb-3">
             <label for="api_key" class="form-label">API Key</label>
-            <input type="text" class="form-control" name="api_key" id="api_key" value="<?= htmlspecialchars($apiKey) ?>" required>
+            <input type="text" class="form-control" name="api_key" id="api_key" value="<?= htmlspecialchars($apiKey) ?>">
         </div>
-        <button type="submit" class="btn btn-secondary">Guardar API Key</button>
+        <div class="mb-3">
+            <label for="default_extension" class="form-label">Extensión por defecto</label>
+            <input type="text" class="form-control" name="default_extension" id="default_extension" value="<?= htmlspecialchars($defaultExtension) ?>">
+        </div>
+        <button type="submit" class="btn btn-secondary">Guardar configuración</button>
     </form>
 
     <h2>Llamada inmediata</h2>
@@ -161,41 +159,36 @@ if ($extension !== '' && $number !== '') {
         <button type="submit" class="btn btn-primary">Llamar</button>
     </form>
 
-    <h2>Configurar calendario</h2>
-    <form method="post">
-        <input type="hidden" name="action" value="save_dates">
+    <h2>Códigos</h2>
+    <form method="post" class="mb-3">
+        <input type="hidden" name="action" value="save_code">
         <div class="row mb-3">
             <div class="col">
-                <label for="extension2" class="form-label">Extensión</label>
-                <input type="text" class="form-control" name="extension" id="extension2" value="<?= htmlspecialchars($extension) ?>" required>
+                <label for="code_name" class="form-label">Nombre</label>
+                <input type="text" class="form-control" name="code_name" id="code_name" required>
             </div>
             <div class="col">
-                <label for="number2" class="form-label">Código</label>
-                <input type="text" class="form-control" name="number" id="number2" value="<?= htmlspecialchars($number) ?>" required>
+                <label for="code_value" class="form-label">Código</label>
+                <input type="text" class="form-control" name="code_value" id="code_value" required>
             </div>
         </div>
-        <div class="mb-3">
-            <label for="datePicker" class="form-label">Fechas</label>
-            <input type="text" id="datePicker" class="form-control">
-            <input type="hidden" name="dates" id="dates">
-        </div>
-        <button type="submit" class="btn btn-success">Guardar fechas</button>
+        <button type="submit" class="btn btn-secondary">Guardar código</button>
     </form>
+
+    <?php if ($codes): ?>
+    <table class="table table-striped">
+        <thead><tr><th>Nombre</th><th>Código</th></tr></thead>
+        <tbody>
+        <?php foreach ($codes as $c): ?>
+            <tr>
+                <td><?= htmlspecialchars($c['name']) ?></td>
+                <td><?= htmlspecialchars($c['code']) ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-<script>
-var selectedDates = <?php echo json_encode($selectedDates); ?>;
-var fp = flatpickr("#datePicker", {
-    mode: "multiple",
-    dateFormat: "Y-m-d",
-    defaultDate: selectedDates,
-    onChange: function(selDates, dateStr, instance) {
-        document.getElementById('dates').value = selDates.map(function(d){return instance.formatDate(d, "Y-m-d");}).join(',');
-    }
-});
-// Initialize hidden input with default dates
- document.getElementById('dates').value = selectedDates.join(',');
-</script>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -46,6 +46,7 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
         <div class="navbar-nav">
             <a class="nav-link active" href="index.php">Historial</a>
             <a class="nav-link" href="config.php">Configuración</a>
+            <a class="nav-link" href="calendar.php">Calendario</a>
         </div>
     </div>
 </nav>
@@ -74,7 +75,7 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
                 <td><?= htmlspecialchars($row['number']) ?></td>
                 <td><?= htmlspecialchars($row['scheduled_at']) ?></td>
                 <td><?= htmlspecialchars($row['executed_at'] ?? '-') ?></td>
-                <td><a class="btn btn-sm btn-primary" href="config.php?extension=<?= urlencode($row['extension']) ?>&number=<?= urlencode($row['number']) ?>">Editar</a></td>
+                <td><a class="btn btn-sm btn-primary" href="calendar.php?extension=<?= urlencode($row['extension']) ?>&number=<?= urlencode($row['number']) ?>">Editar</a></td>
             </tr>
         <?php endforeach; ?>
         </tbody>

--- a/run_scheduled.php
+++ b/run_scheduled.php
@@ -27,8 +27,13 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS settings (
     id INT PRIMARY KEY,
-    api_key VARCHAR(255) NOT NULL
+    api_key VARCHAR(255) NOT NULL,
+    default_extension VARCHAR(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+try {
+    $pdo->exec('ALTER TABLE settings ADD COLUMN default_extension VARCHAR(255) DEFAULT NULL');
+} catch (PDOException $e) {
+}
 
 $apiKey = $pdo->query('SELECT api_key FROM settings WHERE id = 1')->fetchColumn();
 


### PR DESCRIPTION
## Summary
- Allow saving codes with names and a default extension in settings
- Move calendar configuration to its own page with dropdown of saved codes
- Set calendar week to start on Monday via Spanish locale

## Testing
- `php -l config.php`
- `php -l calendar.php`
- `php -l index.php`
- `php -l run_scheduled.php`


------
https://chatgpt.com/codex/tasks/task_e_68c11a93eac8832ead3707885194fbbd