### PR TITLE
Add editable codes and time-based scheduling

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -52,7 +52,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';
     if ($action === 'save_dates') {
         $dates = $_POST['dates'] ?? '';
-        if ($extension !== '' && $number !== '') {
+        $time = trim($_POST['time'] ?? '00:00');
+        if ($extension !== '' && $number !== '' && $time !== '') {
             $pdo->prepare('DELETE FROM scheduled_calls WHERE extension = :extension AND number = :number AND executed_at IS NULL')
                 ->execute([':extension' => $extension, ':number' => $number]);
 
@@ -63,7 +64,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $insert->execute([
                         ':extension' => $extension,
                         ':number' => $number,
-                        ':scheduled_at' => $d . ' 00:00:00'
+                        ':scheduled_at' => $d . ' ' . $time . ':00'
                     ]);
                 }
                 $message = 'Fechas actualizadas.';
@@ -77,10 +78,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $selectedDates = [];
+$selectedTime = '00:00';
 if ($extension !== '' && $number !== '') {
-    $stmt = $pdo->prepare('SELECT DATE(scheduled_at) AS d FROM scheduled_calls WHERE extension = :extension AND number = :number AND executed_at IS NULL');
+    $stmt = $pdo->prepare('SELECT DATE(scheduled_at) AS d, TIME(scheduled_at) AS t FROM scheduled_calls WHERE extension = :extension AND number = :number AND executed_at IS NULL');
     $stmt->execute([':extension' => $extension, ':number' => $number]);
-    $selectedDates = array_column($stmt->fetchAll(), 'd');
+    $rows = $stmt->fetchAll();
+    $selectedDates = array_column($rows, 'd');
+    if ($rows) {
+        $selectedTime = substr($rows[0]['t'], 0, 5);
+    }
+}
+
+$allScheduled = $pdo->query('SELECT DATE(sc.scheduled_at) AS d, sc.number, c.name FROM scheduled_calls sc JOIN codes c ON sc.number = c.code WHERE sc.executed_at IS NULL')->fetchAll();
+$codeSchedules = [];
+$codeColors = [];
+$palette = ['#0d6efd', '#198754', '#dc3545', '#ffc107', '#0dcaf0', '#6f42c1', '#fd7e14'];
+$ci = 0;
+foreach ($allScheduled as $row) {
+    $code = $row['number'];
+    if (!isset($codeSchedules[$code])) {
+        $codeSchedules[$code] = ['name' => $row['name'], 'dates' => []];
+        $codeColors[$code] = $palette[$ci % count($palette)];
+        $ci++;
+    }
+    $codeSchedules[$code]['dates'][] = $row['d'];
 }
 ?>
 <!DOCTYPE html>
@@ -90,6 +111,16 @@ if ($extension !== '' && $number !== '') {
     <title>Calendario</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
+    <style>
+    .schedule-dot{
+        position:absolute;
+        width:6px;
+        height:6px;
+        border-radius:50%;
+        bottom:2px;
+        right:2px;
+    }
+    </style>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
@@ -127,6 +158,10 @@ if ($extension !== '' && $number !== '') {
                     <?php endforeach; ?>
                 </select>
             </div>
+            <div class="col">
+                <label for="time" class="form-label">Hora</label>
+                <input type="time" class="form-control" name="time" id="time" value="<?= htmlspecialchars($selectedTime) ?>" required>
+            </div>
         </div>
         <div class="mb-3">
             <label for="datePicker" class="form-label">Fechas</label>
@@ -135,6 +170,12 @@ if ($extension !== '' && $number !== '') {
         </div>
         <button type="submit" class="btn btn-success">Guardar fechas</button>
     </form>
+    <div class="mt-3">
+        <?php foreach ($codeColors as $code => $color): ?>
+            <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
+            <?= htmlspecialchars($codeSchedules[$code]['name']) ?>&nbsp;
+        <?php endforeach; ?>
+    </div>
 <?php endif; ?>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
@@ -142,6 +183,8 @@ if ($extension !== '' && $number !== '') {
 <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/es.js"></script>
 <script>
 var selectedDates = <?php echo json_encode($selectedDates); ?>;
+var codeSchedules = <?php echo json_encode($codeSchedules); ?>;
+var codeColors = <?php echo json_encode($codeColors); ?>;
 flatpickr("#datePicker", {
     locale: "es",
     mode: "multiple",
@@ -149,6 +192,17 @@ flatpickr("#datePicker", {
     defaultDate: selectedDates,
     onChange: function(selDates, dateStr, instance) {
         document.getElementById('dates').value = selDates.map(function(d){return instance.formatDate(d, 'Y-m-d');}).join(',');
+    },
+    onDayCreate: function(dObj, dStr, fp, dayElem) {
+        var date = fp.formatDate(dayElem.dateObj, "Y-m-d");
+        Object.keys(codeSchedules).forEach(function(code) {
+            if (codeSchedules[code].dates.indexOf(date) !== -1) {
+                var span = document.createElement('span');
+                span.className = 'schedule-dot';
+                span.style.backgroundColor = codeColors[code];
+                dayElem.appendChild(span);
+            }
+        });
     }
 });
 document.getElementById('dates').value = selectedDates.join(',');

--- a/config.php
+++ b/config.php
@@ -58,6 +58,14 @@ $message = '';
 $extension = trim($_POST['extension'] ?? $_GET['extension'] ?? $defaultExtension);
 $number = trim($_POST['number'] ?? $_GET['number'] ?? '');
 
+$editId = intval($_GET['edit_id'] ?? 0);
+$editCode = null;
+if ($editId) {
+    $stmt = $pdo->prepare('SELECT id, name, code FROM codes WHERE id = :id');
+    $stmt->execute([':id' => $editId]);
+    $editCode = $stmt->fetch();
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';
 
@@ -92,19 +100,45 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $message = 'Both extension and code are required.';
         }
     } elseif ($action === 'save_code') {
+        $codeId = intval($_POST['code_id'] ?? 0);
         $codeName = trim($_POST['code_name'] ?? '');
         $codeValue = trim($_POST['code_value'] ?? '');
         if ($codeName !== '' && $codeValue !== '') {
-            $stmt = $pdo->prepare('INSERT INTO codes(name, code) VALUES (:name, :code) ON DUPLICATE KEY UPDATE name=VALUES(name)');
-            $stmt->execute([':name' => $codeName, ':code' => $codeValue]);
-            $message = 'Código guardado.';
+            if ($codeId) {
+                $stmt = $pdo->prepare('SELECT code FROM codes WHERE id = :id');
+                $stmt->execute([':id' => $codeId]);
+                $oldCode = $stmt->fetchColumn();
+                $stmt = $pdo->prepare('UPDATE codes SET name = :name, code = :code WHERE id = :id');
+                $stmt->execute([':name' => $codeName, ':code' => $codeValue, ':id' => $codeId]);
+                if ($oldCode && $oldCode !== $codeValue) {
+                    $stmt = $pdo->prepare('UPDATE scheduled_calls SET number = :new WHERE number = :old');
+                    $stmt->execute([':new' => $codeValue, ':old' => $oldCode]);
+                }
+                $message = 'Código actualizado.';
+            } else {
+                $stmt = $pdo->prepare('INSERT INTO codes(name, code) VALUES (:name, :code)');
+                $stmt->execute([':name' => $codeName, ':code' => $codeValue]);
+                $message = 'Código guardado.';
+            }
         } else {
             $message = 'Nombre y código son obligatorios.';
+        }
+    } elseif ($action === 'delete_code') {
+        $codeId = intval($_POST['code_id'] ?? 0);
+        if ($codeId) {
+            $stmt = $pdo->prepare('SELECT code FROM codes WHERE id = :id');
+            $stmt->execute([':id' => $codeId]);
+            $codeValue = $stmt->fetchColumn();
+            if ($codeValue !== false) {
+                $pdo->prepare('DELETE FROM codes WHERE id = :id')->execute([':id' => $codeId]);
+                $pdo->prepare('DELETE FROM scheduled_calls WHERE number = :code')->execute([':code' => $codeValue]);
+                $message = 'Código eliminado.';
+            }
         }
     }
 }
 
-$codes = $pdo->query('SELECT name, code FROM codes ORDER BY name')->fetchAll();
+$codes = $pdo->query('SELECT id, name, code FROM codes ORDER BY name')->fetchAll();
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -162,27 +196,41 @@ $codes = $pdo->query('SELECT name, code FROM codes ORDER BY name')->fetchAll();
     <h2>Códigos</h2>
     <form method="post" class="mb-3">
         <input type="hidden" name="action" value="save_code">
+        <?php if ($editCode): ?>
+            <input type="hidden" name="code_id" value="<?= $editCode['id'] ?>">
+        <?php endif; ?>
         <div class="row mb-3">
             <div class="col">
                 <label for="code_name" class="form-label">Nombre</label>
-                <input type="text" class="form-control" name="code_name" id="code_name" required>
+                <input type="text" class="form-control" name="code_name" id="code_name" value="<?= htmlspecialchars($editCode['name'] ?? '') ?>" required>
             </div>
             <div class="col">
                 <label for="code_value" class="form-label">Código</label>
-                <input type="text" class="form-control" name="code_value" id="code_value" required>
+                <input type="text" class="form-control" name="code_value" id="code_value" value="<?= htmlspecialchars($editCode['code'] ?? '') ?>" required>
             </div>
         </div>
-        <button type="submit" class="btn btn-secondary">Guardar código</button>
+        <button type="submit" class="btn btn-secondary"><?= $editCode ? 'Actualizar código' : 'Guardar código' ?></button>
+        <?php if ($editCode): ?>
+            <a href="config.php" class="btn btn-link">Cancelar</a>
+        <?php endif; ?>
     </form>
 
     <?php if ($codes): ?>
     <table class="table table-striped">
-        <thead><tr><th>Nombre</th><th>Código</th></tr></thead>
+        <thead><tr><th>Nombre</th><th>Código</th><th>Acciones</th></tr></thead>
         <tbody>
         <?php foreach ($codes as $c): ?>
             <tr>
                 <td><?= htmlspecialchars($c['name']) ?></td>
                 <td><?= htmlspecialchars($c['code']) ?></td>
+                <td>
+                    <a class="btn btn-sm btn-primary" href="config.php?edit_id=<?= $c['id'] ?>">Editar</a>
+                    <form method="post" style="display:inline-block" onsubmit="return confirm('¿Eliminar código?');">
+                        <input type="hidden" name="action" value="delete_code">
+                        <input type="hidden" name="code_id" value="<?= $c['id'] ?>">
+                        <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                    </form>
+                </td>
             </tr>
         <?php endforeach; ?>
         </tbody>

--- a/index.php
+++ b/index.php
@@ -67,12 +67,12 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
 
     <h2>Llamadas programadas</h2>
     <table class="table table-striped">
-        <thead><tr><th>Extensión</th><th>Código</th><th>Programada</th><th>Ejecutada</th><th>Editar</th></tr></thead>
+        <thead><tr><th>Extensión</th><th>Nombre del código</th><th>Programada</th><th>Ejecutada</th><th>Editar</th></tr></thead>
         <tbody>
-        <?php foreach ($pdo->query('SELECT extension, number, scheduled_at, executed_at FROM scheduled_calls ORDER BY id DESC') as $row): ?>
+        <?php foreach ($pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, sc.executed_at, c.name FROM scheduled_calls sc LEFT JOIN codes c ON sc.number = c.code ORDER BY sc.id DESC') as $row): ?>
             <tr>
                 <td><?= htmlspecialchars($row['extension']) ?></td>
-                <td><?= htmlspecialchars($row['number']) ?></td>
+                <td><?= htmlspecialchars($row['name'] ?? $row['number']) ?></td>
                 <td><?= htmlspecialchars($row['scheduled_at']) ?></td>
                 <td><?= htmlspecialchars($row['executed_at'] ?? '-') ?></td>
                 <td><a class="btn btn-sm btn-primary" href="calendar.php?extension=<?= urlencode($row['extension']) ?>&number=<?= urlencode($row['number']) ?>">Editar</a></td>


### PR DESCRIPTION
## Summary
- Allow editing and deleting stored codes and cascade changes to scheduled calls
- Add time selection and colour-coded code markers to calendar
- Show code names instead of raw codes in scheduled call history

## Testing
- `php -l config.php`
- `php -l calendar.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c11e285098832e8eee1cd1f050e0aa