### PR TITLE
Add calls page and color-coded calendar view

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -52,7 +52,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';
     if ($action === 'save_dates') {
         $dates = $_POST['dates'] ?? '';
-        $time = trim($_POST['time'] ?? '00:00');
+        $time = trim($_POST['time'] ?? '21:00');
         if ($extension !== '' && $number !== '' && $time !== '') {
             $pdo->prepare('DELETE FROM scheduled_calls WHERE extension = :extension AND number = :number AND executed_at IS NULL')
                 ->execute([':extension' => $extension, ':number' => $number]);
@@ -78,7 +78,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $selectedDates = [];
-$selectedTime = '00:00';
+$selectedTime = '21:00';
 if ($extension !== '' && $number !== '') {
     $stmt = $pdo->prepare('SELECT DATE(scheduled_at) AS d, TIME(scheduled_at) AS t FROM scheduled_calls WHERE extension = :extension AND number = :number AND executed_at IS NULL');
     $stmt->execute([':extension' => $extension, ':number' => $number]);
@@ -134,6 +134,7 @@ foreach ($allScheduled as $row) {
         <a class="navbar-brand" href="#">Marcación Siptize</a>
         <div class="navbar-nav">
             <a class="nav-link" href="index.php">Historial</a>
+            <a class="nav-link" href="calls.php">Llamadas</a>
             <a class="nav-link" href="config.php">Configuración</a>
             <a class="nav-link active" href="calendar.php">Calendario</a>
         </div>
@@ -220,7 +221,7 @@ document.getElementById('number').addEventListener('change', function() {
         .then(function(response) { return response.json(); })
         .then(function(data) {
             selectedDates = data.dates || [];
-            document.getElementById('time').value = data.time || '00:00';
+            document.getElementById('time').value = data.time || '21:00';
             fp.setDate(selectedDates, false);
             document.getElementById('dates').value = selectedDates.join(',');
         });

--- a/calls.php
+++ b/calls.php
@@ -1,0 +1,125 @@
+<?php
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME') ?: 'multivoice';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: 'terminal';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+$pdo = new PDO($dsn, $user, $pass, $options);
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS calls (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    extension VARCHAR(255) NOT NULL,
+    number VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS settings (
+    id INT PRIMARY KEY,
+    api_key VARCHAR(255) NOT NULL,
+    default_extension VARCHAR(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+try {
+    $pdo->exec('ALTER TABLE settings ADD COLUMN default_extension VARCHAR(255) DEFAULT NULL');
+} catch (PDOException $e) {
+}
+
+$settings = $pdo->query('SELECT api_key, default_extension FROM settings WHERE id = 1')->fetch() ?: [];
+$apiKey = $settings['api_key'] ?? '';
+$defaultExtension = $settings['default_extension'] ?? '';
+
+$message = '';
+$extension = trim($_POST['extension'] ?? $_GET['extension'] ?? $defaultExtension);
+$number = trim($_POST['number'] ?? $_GET['number'] ?? '');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    if ($action === 'call_now') {
+        if ($apiKey === '') {
+            $message = 'API key no configurada.';
+        } elseif ($extension !== '' && $number !== '') {
+            $url = "https://vpbx.me/api/originatecall/" . urlencode($extension) . "/" . urlencode($number) . "?timeout=20&autoAnswer=true";
+            $ch = curl_init($url);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, [
+                'Content-type: application/json',
+                'X-Api-Key: ' . $apiKey
+            ]);
+            $response = curl_exec($ch);
+            $error = curl_error($ch);
+            curl_close($ch);
+
+            $stmt = $pdo->prepare('INSERT INTO calls(extension, number) VALUES (:extension, :number)');
+            $stmt->execute([':extension' => $extension, ':number' => $number]);
+
+            $message = $error ? "Error: $error" : "API response: $response";
+        } else {
+            $message = 'Both extension and code are required.';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Llamadas</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#">Marcación Siptize</a>
+        <div class="navbar-nav">
+            <a class="nav-link" href="index.php">Historial</a>
+            <a class="nav-link active" href="calls.php">Llamadas</a>
+            <a class="nav-link" href="config.php">Configuración</a>
+            <a class="nav-link" href="calendar.php">Calendario</a>
+        </div>
+    </div>
+</nav>
+<div class="container">
+<?php if ($message): ?>
+    <div class="alert alert-info"><?= htmlspecialchars($message) ?></div>
+<?php endif; ?>
+
+    <h2>Llamada inmediata</h2>
+    <form method="post" class="mb-5">
+        <input type="hidden" name="action" value="call_now">
+        <div class="row mb-3">
+            <div class="col">
+                <label for="extension" class="form-label">Extensión</label>
+                <input type="text" class="form-control" name="extension" id="extension" value="<?= htmlspecialchars($extension) ?>" required>
+            </div>
+            <div class="col">
+                <label for="number" class="form-label">Código</label>
+                <input type="text" class="form-control" name="number" id="number" value="<?= htmlspecialchars($number) ?>" required>
+            </div>
+        </div>
+        <button type="submit" class="btn btn-primary">Llamar</button>
+    </form>
+
+    <h2>Llamadas realizadas</h2>
+    <table class="table table-striped">
+        <thead><tr><th>Extensión</th><th>Código</th><th>Fecha</th></tr></thead>
+        <tbody>
+        <?php foreach ($pdo->query('SELECT extension, number, created_at FROM calls ORDER BY id DESC') as $row): ?>
+            <tr>
+                <td><?= htmlspecialchars($row['extension']) ?></td>
+                <td><?= htmlspecialchars($row['number']) ?></td>
+                <td><?= htmlspecialchars($row['created_at']) ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/config.php
+++ b/config.php
@@ -16,14 +16,6 @@ $options = [
 
 $pdo = new PDO($dsn, $user, $pass, $options);
 
-// Ensure required tables exist
-$pdo->exec('CREATE TABLE IF NOT EXISTS calls (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    extension VARCHAR(255) NOT NULL,
-    number VARCHAR(255) NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
-
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,
     extension VARCHAR(255) NOT NULL,
@@ -55,8 +47,6 @@ $apiKey = $settings['api_key'] ?? '';
 $defaultExtension = $settings['default_extension'] ?? '';
 
 $message = '';
-$extension = trim($_POST['extension'] ?? $_GET['extension'] ?? $defaultExtension);
-$number = trim($_POST['number'] ?? $_GET['number'] ?? '');
 
 $editId = intval($_GET['edit_id'] ?? 0);
 $editCode = null;
@@ -77,28 +67,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $apiKey = $newKey;
         $defaultExtension = $newDefault;
         $message = 'Configuración actualizada.';
-    } elseif ($action === 'call_now') {
-        if ($apiKey === '') {
-            $message = 'API key no configurada.';
-        } elseif ($extension !== '' && $number !== '') {
-            $url = "https://vpbx.me/api/originatecall/" . urlencode($extension) . "/" . urlencode($number) . "?timeout=20&autoAnswer=true";
-            $ch = curl_init($url);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($ch, CURLOPT_HTTPHEADER, [
-                'Content-type: application/json',
-                'X-Api-Key: ' . $apiKey
-            ]);
-            $response = curl_exec($ch);
-            $error = curl_error($ch);
-            curl_close($ch);
-
-            $stmt = $pdo->prepare('INSERT INTO calls(extension, number) VALUES (:extension, :number)');
-            $stmt->execute([':extension' => $extension, ':number' => $number]);
-
-            $message = $error ? "Error: $error" : "API response: $response";
-        } else {
-            $message = 'Both extension and code are required.';
-        }
     } elseif ($action === 'save_code') {
         $codeId = intval($_POST['code_id'] ?? 0);
         $codeName = trim($_POST['code_name'] ?? '');
@@ -153,6 +121,7 @@ $codes = $pdo->query('SELECT id, name, code FROM codes ORDER BY name')->fetchAll
         <a class="navbar-brand" href="#">Marcación Siptize</a>
         <div class="navbar-nav">
             <a class="nav-link" href="index.php">Historial</a>
+            <a class="nav-link" href="calls.php">Llamadas</a>
             <a class="nav-link active" href="config.php">Configuración</a>
             <a class="nav-link" href="calendar.php">Calendario</a>
         </div>
@@ -175,22 +144,6 @@ $codes = $pdo->query('SELECT id, name, code FROM codes ORDER BY name')->fetchAll
             <input type="text" class="form-control" name="default_extension" id="default_extension" value="<?= htmlspecialchars($defaultExtension) ?>">
         </div>
         <button type="submit" class="btn btn-secondary">Guardar configuración</button>
-    </form>
-
-    <h2>Llamada inmediata</h2>
-    <form method="post" class="mb-5">
-        <input type="hidden" name="action" value="call_now">
-        <div class="row mb-3">
-            <div class="col">
-                <label for="extension" class="form-label">Extensión</label>
-                <input type="text" class="form-control" name="extension" id="extension" value="<?= htmlspecialchars($extension) ?>" required>
-            </div>
-            <div class="col">
-                <label for="number" class="form-label">Código</label>
-                <input type="text" class="form-control" name="number" id="number" value="<?= htmlspecialchars($number) ?>" required>
-            </div>
-        </div>
-        <button type="submit" class="btn btn-primary">Llamar</button>
     </form>
 
     <h2>Códigos</h2>

--- a/index.php
+++ b/index.php
@@ -1,6 +1,4 @@
 <?php
-// History page styled with Bootstrap
-
 $host = getenv('DB_HOST') ?: 'localhost';
 $db   = getenv('DB_NAME') ?: 'multivoice';
 $user = getenv('DB_USER') ?: 'root';
@@ -16,13 +14,6 @@ $options = [
 
 $pdo = new PDO($dsn, $user, $pass, $options);
 
-$pdo->exec('CREATE TABLE IF NOT EXISTS calls (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    extension VARCHAR(255) NOT NULL,
-    number VARCHAR(255) NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
-
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,
     extension VARCHAR(255) NOT NULL,
@@ -31,6 +22,27 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     executed_at DATETIME DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS codes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    code VARCHAR(255) NOT NULL UNIQUE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+$allScheduled = $pdo->query('SELECT DATE(sc.scheduled_at) AS d, sc.number, c.name FROM scheduled_calls sc JOIN codes c ON sc.number = c.code WHERE sc.executed_at IS NULL')->fetchAll();
+$codeSchedules = [];
+$codeColors = [];
+$palette = ['#0d6efd', '#198754', '#dc3545', '#ffc107', '#0dcaf0', '#6f42c1', '#fd7e14'];
+$ci = 0;
+foreach ($allScheduled as $row) {
+    $code = $row['number'];
+    if (!isset($codeSchedules[$code])) {
+        $codeSchedules[$code] = ['name' => $row['name'], 'dates' => []];
+        $codeColors[$code] = $palette[$ci % count($palette)];
+        $ci++;
+    }
+    $codeSchedules[$code]['dates'][] = $row['d'];
+}
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -38,6 +50,7 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     <meta charset="UTF-8">
     <title>Historial</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
@@ -45,42 +58,42 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
         <a class="navbar-brand" href="#">Marcación Siptize</a>
         <div class="navbar-nav">
             <a class="nav-link active" href="index.php">Historial</a>
+            <a class="nav-link" href="calls.php">Llamadas</a>
             <a class="nav-link" href="config.php">Configuración</a>
             <a class="nav-link" href="calendar.php">Calendario</a>
         </div>
     </div>
 </nav>
 <div class="container">
-    <h2>Llamadas realizadas</h2>
-    <table class="table table-striped">
-        <thead><tr><th>Extensión</th><th>Código</th><th>Fecha</th></tr></thead>
-        <tbody>
-        <?php foreach ($pdo->query('SELECT extension, number, created_at FROM calls ORDER BY id DESC') as $row): ?>
-            <tr>
-                <td><?= htmlspecialchars($row['extension']) ?></td>
-                <td><?= htmlspecialchars($row['number']) ?></td>
-                <td><?= htmlspecialchars($row['created_at']) ?></td>
-            </tr>
+    <h2>Calendario de llamadas programadas</h2>
+    <input type="text" id="calendar" class="form-control">
+    <div class="mt-3">
+        <?php foreach ($codeColors as $code => $color): ?>
+            <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
+            <?= htmlspecialchars($codeSchedules[$code]['name']) ?>&nbsp;
         <?php endforeach; ?>
-        </tbody>
-    </table>
-
-    <h2>Llamadas programadas</h2>
-    <table class="table table-striped">
-        <thead><tr><th>Extensión</th><th>Nombre del código</th><th>Programada</th><th>Ejecutada</th><th>Editar</th></tr></thead>
-        <tbody>
-        <?php foreach ($pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, sc.executed_at, c.name FROM scheduled_calls sc LEFT JOIN codes c ON sc.number = c.code ORDER BY sc.id DESC') as $row): ?>
-            <tr>
-                <td><?= htmlspecialchars($row['extension']) ?></td>
-                <td><?= htmlspecialchars($row['name'] ?? $row['number']) ?></td>
-                <td><?= htmlspecialchars($row['scheduled_at']) ?></td>
-                <td><?= htmlspecialchars($row['executed_at'] ?? '-') ?></td>
-                <td><a class="btn btn-sm btn-primary" href="calendar.php?extension=<?= urlencode($row['extension']) ?>&number=<?= urlencode($row['number']) ?>">Editar</a></td>
-            </tr>
-        <?php endforeach; ?>
-        </tbody>
-    </table>
+    </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/es.js"></script>
+<script>
+var codeSchedules = <?php echo json_encode($codeSchedules); ?>;
+var codeColors = <?php echo json_encode($codeColors); ?>;
+flatpickr("#calendar", {
+    locale: "es",
+    inline: true,
+    clickOpens: false,
+    onDayCreate: function(dObj, dStr, fp, dayElem) {
+        var date = fp.formatDate(dayElem.dateObj, "Y-m-d");
+        Object.keys(codeSchedules).forEach(function(code) {
+            if (codeSchedules[code].dates.indexOf(date) !== -1) {
+                dayElem.style.backgroundColor = codeColors[code];
+                dayElem.style.color = '#fff';
+            }
+        });
+    }
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Default calendar scheduling time set to 21:00
- Introduce `calls.php` page combining immediate call form and call history
- Replace programadas table in Historial with read-only color-coded calendar

## Testing
- `php -l index.php config.php calendar.php calls.php run_scheduled.php`


------
https://chatgpt.com/codex/tasks/task_e_68c12293eff4832ebd1952981344f3d8