### PR TITLE
Set application timezone to Europe/Madrid

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -1,4 +1,5 @@
 <?php
+date_default_timezone_set('Europe/Madrid');
 $host = getenv('DB_HOST') ?: 'localhost';
 $db   = getenv('DB_NAME') ?: 'multivoice';
 $user = getenv('DB_USER') ?: 'root';
@@ -13,6 +14,7 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
+$pdo->exec("SET time_zone = 'Europe/Madrid'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/calls.php
+++ b/calls.php
@@ -1,4 +1,5 @@
 <?php
+date_default_timezone_set('Europe/Madrid');
 $host = getenv('DB_HOST') ?: 'localhost';
 $db   = getenv('DB_NAME') ?: 'multivoice';
 $user = getenv('DB_USER') ?: 'root';
@@ -13,6 +14,7 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
+$pdo->exec("SET time_zone = 'Europe/Madrid'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/config.php
+++ b/config.php
@@ -1,4 +1,5 @@
 <?php
+date_default_timezone_set('Europe/Madrid');
 // Configuration page with multi-date calendar using Bootstrap and Flatpickr
 
 $host = getenv('DB_HOST') ?: 'localhost';
@@ -15,6 +16,7 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
+$pdo->exec("SET time_zone = 'Europe/Madrid'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+date_default_timezone_set('Europe/Madrid');
 $host = getenv('DB_HOST') ?: 'localhost';
 $db   = getenv('DB_NAME') ?: 'multivoice';
 $user = getenv('DB_USER') ?: 'root';
@@ -13,6 +14,7 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
+$pdo->exec("SET time_zone = 'Europe/Madrid'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/run_scheduled.php
+++ b/run_scheduled.php
@@ -1,4 +1,5 @@
 <?php
+date_default_timezone_set('Europe/Madrid');
 // Execute scheduled calls due at the current time
 
 $host = getenv('DB_HOST') ?: 'localhost';
@@ -15,6 +16,7 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
+$pdo->exec("SET time_zone = 'Europe/Madrid'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Ensure all PHP entrypoints use Madrid time.
- Configure MySQL sessions to Europe/Madrid for consistent scheduling.

## Testing
- `php -l run_scheduled.php`
- `php -l calendar.php`
- `php -l config.php`
- `php -l index.php`
- `php -l calls.php`


------
https://chatgpt.com/codex/tasks/task_e_68c14350584c832e92f35856686c0104