### PR TITLE
Handle missing MySQL timezone data

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -14,7 +14,7 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
-$pdo->exec("SET time_zone = 'Europe/Madrid'");
+$pdo->exec("SET time_zone = '" . date('P') . "'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/calls.php
+++ b/calls.php
@@ -14,7 +14,7 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
-$pdo->exec("SET time_zone = 'Europe/Madrid'");
+$pdo->exec("SET time_zone = '" . date('P') . "'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/config.php
+++ b/config.php
@@ -16,7 +16,7 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
-$pdo->exec("SET time_zone = 'Europe/Madrid'");
+$pdo->exec("SET time_zone = '" . date('P') . "'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/index.php
+++ b/index.php
@@ -14,7 +14,7 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
-$pdo->exec("SET time_zone = 'Europe/Madrid'");
+$pdo->exec("SET time_zone = '" . date('P') . "'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/run_scheduled.php
+++ b/run_scheduled.php
@@ -16,7 +16,7 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
-$pdo->exec("SET time_zone = 'Europe/Madrid'");
+$pdo->exec("SET time_zone = '" . date('P') . "'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Use the PHP timezone offset when setting MySQL `time_zone` to avoid unknown timezone errors

## Testing
- `php -l index.php config.php calendar.php calls.php run_scheduled.php`


------
https://chatgpt.com/codex/tasks/task_e_68c146377014832e96b0964a7bf1599d