### PR TITLE
Add configurable timezone for scheduled calls

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -1,5 +1,6 @@
 <?php
-date_default_timezone_set('Europe/Madrid');
+$timezone = getenv('APP_TZ') ?: 'Europe/Madrid';
+date_default_timezone_set($timezone);
 $host = getenv('DB_HOST') ?: 'localhost';
 $db   = getenv('DB_NAME') ?: 'multivoice';
 $user = getenv('DB_USER') ?: 'root';
@@ -14,7 +15,9 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
-$pdo->exec("SET time_zone = '" . date('P') . "'");
+$tz = new DateTimeZone($timezone);
+$offset = (new DateTime('now', $tz))->format('P');
+$pdo->exec("SET time_zone = '$offset'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/calls.php
+++ b/calls.php
@@ -1,5 +1,6 @@
 <?php
-date_default_timezone_set('Europe/Madrid');
+$timezone = getenv('APP_TZ') ?: 'Europe/Madrid';
+date_default_timezone_set($timezone);
 $host = getenv('DB_HOST') ?: 'localhost';
 $db   = getenv('DB_NAME') ?: 'multivoice';
 $user = getenv('DB_USER') ?: 'root';
@@ -14,7 +15,9 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
-$pdo->exec("SET time_zone = '" . date('P') . "'");
+$tz = new DateTimeZone($timezone);
+$offset = (new DateTime('now', $tz))->format('P');
+$pdo->exec("SET time_zone = '$offset'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/config.php
+++ b/config.php
@@ -1,5 +1,6 @@
 <?php
-date_default_timezone_set('Europe/Madrid');
+$timezone = getenv('APP_TZ') ?: 'Europe/Madrid';
+date_default_timezone_set($timezone);
 // Configuration page with multi-date calendar using Bootstrap and Flatpickr
 
 $host = getenv('DB_HOST') ?: 'localhost';
@@ -16,7 +17,9 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
-$pdo->exec("SET time_zone = '" . date('P') . "'");
+$tz = new DateTimeZone($timezone);
+$offset = (new DateTime('now', $tz))->format('P');
+$pdo->exec("SET time_zone = '$offset'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
-date_default_timezone_set('Europe/Madrid');
+$timezone = getenv('APP_TZ') ?: 'Europe/Madrid';
+date_default_timezone_set($timezone);
 $host = getenv('DB_HOST') ?: 'localhost';
 $db   = getenv('DB_NAME') ?: 'multivoice';
 $user = getenv('DB_USER') ?: 'root';
@@ -14,7 +15,9 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
-$pdo->exec("SET time_zone = '" . date('P') . "'");
+$tz = new DateTimeZone($timezone);
+$offset = (new DateTime('now', $tz))->format('P');
+$pdo->exec("SET time_zone = '$offset'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/run_scheduled.php
+++ b/run_scheduled.php
@@ -1,5 +1,7 @@
 <?php
-date_default_timezone_set('Europe/Madrid');
+// Allow timezone configuration via APP_TZ environment variable (defaults to Europe/Madrid)
+$timezone = getenv('APP_TZ') ?: 'Europe/Madrid';
+date_default_timezone_set($timezone);
 // Execute scheduled calls due at the current time
 
 $host = getenv('DB_HOST') ?: 'localhost';
@@ -16,7 +18,9 @@ $options = [
 ];
 
 $pdo = new PDO($dsn, $user, $pass, $options);
-$pdo->exec("SET time_zone = '" . date('P') . "'");
+$tz = new DateTimeZone($timezone);
+$offset = (new DateTime('now', $tz))->format('P');
+$pdo->exec("SET time_zone = '$offset'");
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- allow overriding default Europe/Madrid timezone using APP_TZ env var
- apply timezone offset to MySQL sessions across scripts

## Testing
- `php -l run_scheduled.php`
- `php -l calendar.php`
- `php -l calls.php`
- `php -l config.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c148cab9d4832ebef845298ad29d97