### PR TITLE
Center and enlarge calendar on index page

### DIFF
--- a/index.php
+++ b/index.php
@@ -56,6 +56,12 @@ foreach ($allScheduled as $row) {
     <title>Historial</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
+    <style>
+    #calendarWrapper .flatpickr-calendar {
+        transform: scale(1.3);
+        transform-origin: top center;
+    }
+    </style>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
@@ -71,7 +77,9 @@ foreach ($allScheduled as $row) {
 </nav>
 <div class="container">
     <h2 style="margin-bottom:20px">Calendario</h2>
-    <input type="text" id="calendar" class="form-control">
+    <div id="calendarWrapper" class="d-flex justify-content-center">
+        <input type="text" id="calendar" class="form-control">
+    </div>
     <div class="mt-3">
         <?php foreach ($codeColors as $code => $color): ?>
             <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>


### PR DESCRIPTION
## Summary
- Scale up the inline calendar and center it using a flex wrapper

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c14f7387b0832eaeb30b0d6f6b27a1