### PR TITLE
Send notification emails when calls execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Interfaz web en PHP para realizar llamadas mediante la API de Siptize.
 
 ## Uso
 
-1. Abra `config.php` para configurar la API key, realizar llamadas inmediatas o configurar múltiples fechas para cada combinación de extensión y código.
+1. Abra `config.php` para configurar la API key, la dirección de correo de notificación, realizar llamadas inmediatas o configurar múltiples fechas para cada combinación de extensión y código.
 2. Seleccione las fechas desde el calendario (puede marcar varias) y guárdelas; los días seleccionados se almacenan en la base de datos y aparecerán resaltados al volver a abrir la página.
 3. El historial de llamadas y de fechas programadas se visualiza en `index.php`.
 4. Configure las variables de entorno `DB_HOST`, `DB_NAME`, `DB_USER` y `DB_PASS` o edite los archivos PHP con sus credenciales de MySQL.
-5. Ejecute periódicamente `run_scheduled.php` (por ejemplo, con `cron`) para que las llamadas pendientes se realicen en la fecha indicada.
+5. Ejecute periódicamente `run_scheduled.php` (por ejemplo, con `cron`) para que las llamadas pendientes se realicen en la fecha indicada. Se enviará un correo de notificación cuando se ejecute cada llamada.
 
 La interfaz utiliza Bootstrap para un diseño más amigable y Flatpickr para el calendario de selección múltiple.

--- a/calendar.php
+++ b/calendar.php
@@ -32,13 +32,17 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS settings (
     id INT PRIMARY KEY,
     api_key VARCHAR(255) NOT NULL,
     default_extension VARCHAR(255) DEFAULT NULL,
-    execution_time VARCHAR(5) DEFAULT "21:00"
+    execution_time VARCHAR(5) DEFAULT "21:00",
+    notification_email VARCHAR(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 try {
     $pdo->exec('ALTER TABLE settings ADD COLUMN default_extension VARCHAR(255) DEFAULT NULL');
 } catch (PDOException $e) {}
 try {
     $pdo->exec("ALTER TABLE settings ADD COLUMN execution_time VARCHAR(5) DEFAULT '21:00'");
+} catch (PDOException $e) {}
+try {
+    $pdo->exec('ALTER TABLE settings ADD COLUMN notification_email VARCHAR(255) DEFAULT NULL');
 } catch (PDOException $e) {}
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS behaviors (

--- a/calls.php
+++ b/calls.php
@@ -29,10 +29,20 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS calls (
 $pdo->exec('CREATE TABLE IF NOT EXISTS settings (
     id INT PRIMARY KEY,
     api_key VARCHAR(255) NOT NULL,
-    default_extension VARCHAR(255) DEFAULT NULL
+    default_extension VARCHAR(255) DEFAULT NULL,
+    execution_time VARCHAR(5) DEFAULT "21:00",
+    notification_email VARCHAR(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 try {
     $pdo->exec('ALTER TABLE settings ADD COLUMN default_extension VARCHAR(255) DEFAULT NULL');
+} catch (PDOException $e) {
+}
+try {
+    $pdo->exec("ALTER TABLE settings ADD COLUMN execution_time VARCHAR(5) DEFAULT '21:00'");
+} catch (PDOException $e) {
+}
+try {
+    $pdo->exec('ALTER TABLE settings ADD COLUMN notification_email VARCHAR(255) DEFAULT NULL');
 } catch (PDOException $e) {
 }
 
@@ -42,9 +52,10 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS behaviors (
     code VARCHAR(255) NOT NULL UNIQUE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 
-$settings = $pdo->query('SELECT api_key, default_extension FROM settings WHERE id = 1')->fetch() ?: [];
+$settings = $pdo->query('SELECT api_key, default_extension, notification_email FROM settings WHERE id = 1')->fetch() ?: [];
 $apiKey = $settings['api_key'] ?? '';
 $defaultExtension = $settings['default_extension'] ?? '';
+$notificationEmail = $settings['notification_email'] ?? '';
 
 $behaviors = $pdo->query('SELECT name, code FROM behaviors ORDER BY name')->fetchAll();
 
@@ -73,6 +84,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt->execute([':extension' => $extension, ':number' => $number]);
 
             $message = $error ? "Error: $error" : "API response: $response";
+            if ($notificationEmail !== '') {
+                $subject = 'Llamada inmediata ejecutada';
+                $body = "Extensión: $extension\nComportamiento: $number\n";
+                $body .= $error ? "Error: $error" : "Respuesta: $response";
+                @mail($notificationEmail, $subject, $body);
+            }
         } else {
             $message = 'Both extension and comportamiento are required.';
         }

--- a/config.php
+++ b/config.php
@@ -33,7 +33,9 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
 $pdo->exec('CREATE TABLE IF NOT EXISTS settings (
     id INT PRIMARY KEY,
     api_key VARCHAR(255) NOT NULL,
-    default_extension VARCHAR(255) DEFAULT NULL
+    default_extension VARCHAR(255) DEFAULT NULL,
+    execution_time VARCHAR(5) DEFAULT "21:00",
+    notification_email VARCHAR(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 try {
     $pdo->exec('ALTER TABLE settings ADD COLUMN default_extension VARCHAR(255) DEFAULT NULL');
@@ -52,10 +54,16 @@ try {
 } catch (PDOException $e) {
     // Column may already exist
 }
-$settings = $pdo->query('SELECT api_key, default_extension, execution_time FROM settings WHERE id = 1')->fetch() ?: [];
+try {
+    $pdo->exec('ALTER TABLE settings ADD COLUMN notification_email VARCHAR(255) DEFAULT NULL');
+} catch (PDOException $e) {
+    // Column may already exist
+}
+$settings = $pdo->query('SELECT api_key, default_extension, execution_time, notification_email FROM settings WHERE id = 1')->fetch() ?: [];
 $apiKey = $settings['api_key'] ?? '';
 $defaultExtension = $settings['default_extension'] ?? '';
 $executionTime = $settings['execution_time'] ?? '21:00';
+$notificationEmail = $settings['notification_email'] ?? '';
 
 $message = '';
 
@@ -74,11 +82,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $newKey = trim($_POST['api_key'] ?? '');
         $newDefault = trim($_POST['default_extension'] ?? '');
         $newTime = trim($_POST['execution_time'] ?? '21:00');
-        $stmt = $pdo->prepare('REPLACE INTO settings (id, api_key, default_extension, execution_time) VALUES (1, :api_key, :default_extension, :execution_time)');
-        $stmt->execute([':api_key' => $newKey, ':default_extension' => $newDefault, ':execution_time' => $newTime]);
+        $newEmail = trim($_POST['notification_email'] ?? '');
+        $stmt = $pdo->prepare('REPLACE INTO settings (id, api_key, default_extension, execution_time, notification_email) VALUES (1, :api_key, :default_extension, :execution_time, :notification_email)');
+        $stmt->execute([':api_key' => $newKey, ':default_extension' => $newDefault, ':execution_time' => $newTime, ':notification_email' => $newEmail]);
         $apiKey = $newKey;
         $defaultExtension = $newDefault;
         $executionTime = $newTime;
+        $notificationEmail = $newEmail;
         $message = 'Configuración actualizada.';
     } elseif ($action === 'save_behavior') {
         $behaviorId = intval($_POST['behavior_id'] ?? 0);
@@ -154,6 +164,10 @@ $behaviors = $pdo->query('SELECT id, name, code FROM behaviors ORDER BY name')->
         <div class="mb-3">
             <label for="default_extension" class="form-label">Extensión por defecto</label>
             <input type="text" class="form-control" name="default_extension" id="default_extension" value="<?= htmlspecialchars($defaultExtension) ?>">
+        </div>
+        <div class="mb-3">
+            <label for="notification_email" class="form-label">Correo de notificación</label>
+            <input type="email" class="form-control" name="notification_email" id="notification_email" value="<?= htmlspecialchars($notificationEmail) ?>">
         </div>
         <div class="mb-3">
             <label for="execution_time" class="form-label">Hora de ejecución</label>

--- a/run_scheduled.php
+++ b/run_scheduled.php
@@ -34,7 +34,9 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
 $pdo->exec('CREATE TABLE IF NOT EXISTS settings (
     id INT PRIMARY KEY,
     api_key VARCHAR(255) NOT NULL,
-    default_extension VARCHAR(255) DEFAULT NULL
+    default_extension VARCHAR(255) DEFAULT NULL,
+    execution_time VARCHAR(5) DEFAULT "21:00",
+    notification_email VARCHAR(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 try {
     $pdo->exec('ALTER TABLE settings ADD COLUMN default_extension VARCHAR(255) DEFAULT NULL');
@@ -44,8 +46,13 @@ try {
     $pdo->exec("ALTER TABLE settings ADD COLUMN execution_time VARCHAR(5) DEFAULT '21:00'");
 } catch (PDOException $e) {
 }
-
-$apiKey = $pdo->query('SELECT api_key FROM settings WHERE id = 1')->fetchColumn();
+try {
+    $pdo->exec('ALTER TABLE settings ADD COLUMN notification_email VARCHAR(255) DEFAULT NULL');
+} catch (PDOException $e) {
+}
+$settings = $pdo->query('SELECT api_key, notification_email FROM settings WHERE id = 1')->fetch();
+$apiKey = $settings['api_key'] ?? '';
+$notificationEmail = $settings['notification_email'] ?? '';
 
 if (!$apiKey) {
     echo "API key not configured\n";
@@ -76,6 +83,13 @@ foreach ($calls as $call) {
         echo "Error for {$call['id']}: $error\n";
     } else {
         echo "Executed {$call['id']}: $response\n";
+    }
+
+    if ($notificationEmail) {
+        $subject = "Llamada programada ejecutada";
+        $body = "Extensión: {$call['extension']}\nComportamiento: {$call['number']}\n";
+        $body .= $error ? "Error: $error" : "Respuesta: $response";
+        @mail($notificationEmail, $subject, $body);
     }
 }
 


### PR DESCRIPTION
## Summary
- allow configuring a notification email address
- send an email every time a scheduled or immediate call runs
- document the new notification email feature in README

## Testing
- `php -l config.php`
- `php -l run_scheduled.php`
- `php -l calls.php`
- `php -l calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1563c1f18832eaea35f1fbd9d7c25