### PR TITLE
Evita llamadas repetidas en periodos sin cambio

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__ . '/db.php';
+require __DIR__ . '/schedule_utils.php';
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
     id INT AUTO_INCREMENT PRIMARY KEY,
@@ -16,13 +17,17 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS settings (
     default_extension VARCHAR(255) DEFAULT NULL,
     execution_time VARCHAR(5) DEFAULT "21:00",
     telegram_bot_id VARCHAR(255) DEFAULT NULL,
-    telegram_chat_id VARCHAR(255) DEFAULT NULL
+    telegram_chat_id VARCHAR(255) DEFAULT NULL,
+    change_timing VARCHAR(10) DEFAULT "start"
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 try {
     $pdo->exec('ALTER TABLE settings ADD COLUMN default_extension VARCHAR(255) DEFAULT NULL');
 } catch (PDOException $e) {}
 try {
     $pdo->exec("ALTER TABLE settings ADD COLUMN execution_time VARCHAR(5) DEFAULT '21:00'");
+} catch (PDOException $e) {}
+try {
+    $pdo->exec("ALTER TABLE settings ADD COLUMN change_timing VARCHAR(10) DEFAULT 'start'");
 } catch (PDOException $e) {}
 try {
     $pdo->exec('ALTER TABLE settings ADD COLUMN telegram_bot_id VARCHAR(255) DEFAULT NULL');
@@ -47,33 +52,11 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS behavior_days (
     day DATE NOT NULL UNIQUE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 
-$settings = $pdo->query('SELECT default_extension, execution_time FROM settings WHERE id = 1')->fetch() ?: [];
+$settings = $pdo->query('SELECT default_extension, execution_time, change_timing FROM settings WHERE id = 1')->fetch() ?: [];
 $defaultExtension = $settings['default_extension'] ?? '';
 $executionTime = $settings['execution_time'] ?? '21:00';
+$changeTiming = $settings['change_timing'] ?? 'start';
 
-// Helper to rebuild scheduled calls for a behavior
-function reprogramBehavior($pdo, $behaviorId, $defaultExtension, $executionTime) {
-    if (!$defaultExtension) {
-        return;
-    }
-    $stmt = $pdo->prepare('SELECT code FROM behaviors WHERE id = :id');
-    $stmt->execute([':id' => $behaviorId]);
-    $code = $stmt->fetchColumn();
-    if ($code === false) {
-        return;
-    }
-    $pdo->prepare('DELETE FROM scheduled_calls WHERE number = :code AND executed_at IS NULL')->execute([':code' => $code]);
-    $periods = $pdo->prepare('SELECT day FROM behavior_days WHERE behavior_id = :id');
-    $periods->execute([':id' => $behaviorId]);
-    foreach ($periods as $p) {
-        $pdo->prepare('INSERT INTO scheduled_calls(extension, number, scheduled_at) VALUES (:ext, :num, :sched)')
-            ->execute([
-                ':ext' => $defaultExtension,
-                ':num' => $code,
-                ':sched' => $p['day'] . ' ' . $executionTime . ':00'
-            ]);
-    }
-}
 
 $behaviors = $pdo->query('SELECT id, name, code, color FROM behaviors ORDER BY name')->fetchAll();
 
@@ -102,7 +85,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             foreach ($dates as $d) {
                 $ins->execute([':id' => $behaviorId, ':day' => $d]);
             }
-            reprogramBehavior($pdo, $behaviorId, $defaultExtension, $executionTime);
+            rebuildScheduledCalls($pdo, $defaultExtension, $executionTime, $changeTiming);
             $message = 'Días actualizados.';
         }
     } else {

--- a/config.php
+++ b/config.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__ . '/db.php';
+require __DIR__ . '/schedule_utils.php';
 // Configuration page with multi-date calendar using Bootstrap and Flatpickr
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS scheduled_calls (
@@ -17,7 +18,8 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS settings (
     default_extension VARCHAR(255) DEFAULT NULL,
     execution_time VARCHAR(5) DEFAULT "21:00",
     telegram_bot_id VARCHAR(255) DEFAULT NULL,
-    telegram_chat_id VARCHAR(255) DEFAULT NULL
+    telegram_chat_id VARCHAR(255) DEFAULT NULL,
+    change_timing VARCHAR(10) DEFAULT "start"
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 try {
     $pdo->exec('ALTER TABLE settings ADD COLUMN default_extension VARCHAR(255) DEFAULT NULL');
@@ -40,6 +42,11 @@ try {
     // Column may already exist
 }
 try {
+    $pdo->exec("ALTER TABLE settings ADD COLUMN change_timing VARCHAR(10) DEFAULT 'start'");
+} catch (PDOException $e) {
+    // Column may already exist
+}
+try {
     $pdo->exec('ALTER TABLE settings ADD COLUMN telegram_bot_id VARCHAR(255) DEFAULT NULL');
 } catch (PDOException $e) {
     // Column may already exist
@@ -48,10 +55,11 @@ try {
     $pdo->exec('ALTER TABLE settings ADD COLUMN telegram_chat_id VARCHAR(255) DEFAULT NULL');
 } catch (PDOException $e) {}
 
-$settings = $pdo->query('SELECT api_key, default_extension, execution_time, telegram_bot_id, telegram_chat_id FROM settings WHERE id = 1')->fetch() ?: [];
+$settings = $pdo->query('SELECT api_key, default_extension, execution_time, change_timing, telegram_bot_id, telegram_chat_id FROM settings WHERE id = 1')->fetch() ?: [];
 $apiKey = $settings['api_key'] ?? '';
 $defaultExtension = $settings['default_extension'] ?? '';
 $executionTime = $settings['execution_time'] ?? '21:00';
+$changeTiming = $settings['change_timing'] ?? 'start';
 $telegramBotId = $settings['telegram_bot_id'] ?? '';
 $telegramChatId = $settings['telegram_chat_id'] ?? '';
 
@@ -74,14 +82,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $newTime = trim($_POST['execution_time'] ?? '21:00');
         $newBot = trim($_POST['telegram_bot_id'] ?? '');
         $newChat = trim($_POST['telegram_chat_id'] ?? '');
-        $stmt = $pdo->prepare('REPLACE INTO settings (id, api_key, default_extension, execution_time, telegram_bot_id, telegram_chat_id) VALUES (1, :api_key, :default_extension, :execution_time, :telegram_bot_id, :telegram_chat_id)');
-        $stmt->execute([':api_key' => $newKey, ':default_extension' => $newDefault, ':execution_time' => $newTime, ':telegram_bot_id' => $newBot, ':telegram_chat_id' => $newChat]);
+        $newChange = $_POST['change_timing'] ?? 'start';
+        $stmt = $pdo->prepare('REPLACE INTO settings (id, api_key, default_extension, execution_time, change_timing, telegram_bot_id, telegram_chat_id) VALUES (1, :api_key, :default_extension, :execution_time, :change_timing, :telegram_bot_id, :telegram_chat_id)');
+        $stmt->execute([':api_key' => $newKey, ':default_extension' => $newDefault, ':execution_time' => $newTime, ':change_timing' => $newChange, ':telegram_bot_id' => $newBot, ':telegram_chat_id' => $newChat]);
         $apiKey = $newKey;
         $defaultExtension = $newDefault;
         $executionTime = $newTime;
+        $changeTiming = $newChange;
         $telegramBotId = $newBot;
         $telegramChatId = $newChat;
         $message = 'Configuración actualizada.';
+        rebuildScheduledCalls($pdo, $defaultExtension, $executionTime, $changeTiming);
     } elseif ($action === 'send_test_message') {
         $bot = trim($_POST['telegram_bot_id'] ?? $telegramBotId);
         $chat = trim($_POST['telegram_chat_id'] ?? $telegramChatId);
@@ -185,6 +196,13 @@ $behaviors = $pdo->query('SELECT id, name, code, color FROM behaviors ORDER BY n
         <div class="mb-3">
             <label for="execution_time" class="form-label">Hora de ejecución</label>
             <input type="time" class="form-control" name="execution_time" id="execution_time" value="<?= htmlspecialchars($executionTime) ?>">
+        </div>
+        <div class="mb-3">
+            <label for="change_timing" class="form-label">Momento del cambio</label>
+            <select class="form-select" name="change_timing" id="change_timing">
+                <option value="start" <?= $changeTiming === 'start' ? 'selected' : '' ?>>Al inicio del periodo</option>
+                <option value="end" <?= $changeTiming === 'end' ? 'selected' : '' ?>>Al final del periodo</option>
+            </select>
         </div>
         <button type="submit" class="btn btn-secondary">Guardar configuración</button>
     </form>

--- a/run_scheduled.php
+++ b/run_scheduled.php
@@ -17,7 +17,8 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS settings (
     default_extension VARCHAR(255) DEFAULT NULL,
     execution_time VARCHAR(5) DEFAULT "21:00",
     telegram_bot_id VARCHAR(255) DEFAULT NULL,
-    telegram_chat_id VARCHAR(255) DEFAULT NULL
+    telegram_chat_id VARCHAR(255) DEFAULT NULL,
+    change_timing VARCHAR(10) DEFAULT "start"
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 try {
     $pdo->exec('ALTER TABLE settings ADD COLUMN default_extension VARCHAR(255) DEFAULT NULL');
@@ -32,6 +33,9 @@ try {
 } catch (PDOException $e) {}
 try {
     $pdo->exec('ALTER TABLE settings ADD COLUMN telegram_chat_id VARCHAR(255) DEFAULT NULL');
+} catch (PDOException $e) {}
+try {
+    $pdo->exec("ALTER TABLE settings ADD COLUMN change_timing VARCHAR(10) DEFAULT 'start'");
 } catch (PDOException $e) {}
 $pdo->exec('CREATE TABLE IF NOT EXISTS behaviors (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/schedule_utils.php
+++ b/schedule_utils.php
@@ -1,0 +1,59 @@
+<?php
+function nextWorkingDay(DateTime $date): DateTime {
+    $d = clone $date;
+    do {
+        $d->modify('+1 day');
+    } while (in_array($d->format('N'), [6,7]));
+    return $d;
+}
+
+function previousWorkingDay(DateTime $date): DateTime {
+    $d = clone $date;
+    do {
+        $d->modify('-1 day');
+    } while (in_array($d->format('N'), [6,7]));
+    return $d;
+}
+
+function rebuildScheduledCalls(PDO $pdo, string $defaultExtension, string $executionTime, string $changeTiming): void {
+    if ($defaultExtension === '') {
+        return;
+    }
+
+    $pdo->exec("DELETE FROM scheduled_calls WHERE executed_at IS NULL");
+    $stmt = $pdo->query('SELECT bd.day, b.code FROM behavior_days bd JOIN behaviors b ON bd.behavior_id = b.id ORDER BY bd.day');
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $prevDay = null;
+    $prevCode = null;
+
+    foreach ($rows as $row) {
+        $day = new DateTime($row['day']);
+        $code = $row['code'];
+        $shouldSchedule = false;
+        if ($prevCode === null) {
+            $shouldSchedule = true;
+        } else {
+            $expected = nextWorkingDay($prevDay);
+            if ($code !== $prevCode || $expected->format('Y-m-d') !== $day->format('Y-m-d')) {
+                $shouldSchedule = true;
+            }
+        }
+        if ($shouldSchedule) {
+            if ($changeTiming === 'end') {
+                $schedDay = previousWorkingDay($day);
+            } else {
+                $schedDay = $day;
+            }
+            $pdo->prepare('INSERT INTO scheduled_calls(extension, number, scheduled_at) VALUES (:ext, :num, :sched)')
+                ->execute([
+                    ':ext' => $defaultExtension,
+                    ':num' => $code,
+                    ':sched' => $schedDay->format('Y-m-d') . ' ' . $executionTime . ':00'
+                ]);
+        }
+        $prevDay = $day;
+        $prevCode = $code;
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- Programa llamadas solo cuando hay cambios de comportamiento, ignorando fines de semana
- Añade opción para elegir si el cambio se realiza al inicio o al final del periodo
- Reconstruye automáticamente las llamadas programadas al guardar configuración o calendario

## Testing
- `php -l schedule_utils.php config.php calendar.php run_scheduled.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2b7c9a640832e90e7a9ecdfe7f09d