### PR TITLE
Show behavior legend beneath calendar and include names in call log

### DIFF
--- a/calls.php
+++ b/calls.php
@@ -138,10 +138,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <table class="table table-striped">
         <thead><tr><th>Extensión</th><th>Comportamiento</th><th>Fecha</th></tr></thead>
         <tbody>
-        <?php foreach ($pdo->query('SELECT extension, number, created_at FROM calls ORDER BY id DESC') as $row): ?>
+        <?php foreach ($pdo->query('SELECT c.extension, c.number, b.name AS behavior_name, c.created_at FROM calls c LEFT JOIN behaviors b ON c.number = b.code ORDER BY c.id DESC') as $row): ?>
             <tr>
                 <td><?= htmlspecialchars($row['extension']) ?></td>
-                <td><?= htmlspecialchars($row['number']) ?></td>
+                <td><?= htmlspecialchars($row['behavior_name'] ?? '') ?> (<?= htmlspecialchars($row['number']) ?>)</td>
                 <td><?= htmlspecialchars($row['created_at']) ?></td>
             </tr>
         <?php endforeach; ?>

--- a/index.php
+++ b/index.php
@@ -56,14 +56,14 @@ foreach ($allPeriods as $row) {
 </nav>
 <div class="container">
     <h2 class="d-flex justify-content-center mb-3">Calendario</h2>
-    <div id="calendarWrapper" class="d-flex justify-content-center">
+    <div id="calendarWrapper" class="d-flex flex-column align-items-center">
         <input type="text" id="calendar" class="form-control">
-    </div>
-    <div class="mt-3">
-        <?php foreach ($codeColors as $code => $color): ?>
-            <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
-            <?= htmlspecialchars($codeSchedules[$code]['name']) ?>&nbsp;
-        <?php endforeach; ?>
+        <div class="mt-3 text-center">
+            <?php foreach ($codeColors as $code => $color): ?>
+                <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
+                <?= htmlspecialchars($codeSchedules[$code]['name']) ?>&nbsp;
+            <?php endforeach; ?>
+        </div>
     </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- Place behavior-color legend directly below the calendar
- Display behavior name alongside its code in the call history table

## Testing
- `php -l index.php`
- `php -l calls.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3c4bbf7d8832ea0ec2b00c6cfcc44