### PR TITLE
Ensure calendar legend remains visible

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -150,6 +150,12 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
             <p>No hay comportamientos guardados. Agregue uno en Configuración.</p>
         <?php else: ?>
             <h2>Configurar calendario</h2>
+            <div class="mb-3">
+                <?php foreach ($behaviorColors as $code => $color): ?>
+                    <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
+                    <?= htmlspecialchars($behaviorSchedules[$code]['name']) ?>&nbsp;
+                <?php endforeach; ?>
+            </div>
             <form method="post" class="mb-3">
                 <div class="row mb-3">
                     <div class="col">
@@ -171,13 +177,6 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
 
                 <button type="submit" class="btn btn-success">Guardar días</button>
             </form>
-
-            <div class="mt-3">
-                <?php foreach ($behaviorColors as $code => $color): ?>
-                    <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
-                    <?= htmlspecialchars($behaviorSchedules[$code]['name']) ?>&nbsp;
-                <?php endforeach; ?>
-            </div>
         <?php endif; ?>
 
         <?php if (!empty($pendingCalls)): ?>
@@ -217,6 +216,7 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
             mode: "multiple",
             dateFormat: "Y-m-d",
             defaultDate: existingDates,
+            inline: true,
             onChange: function(selDates, dateStr, instance) {
                 var dates = selDates.map(function(d) {
                     return instance.formatDate(d, 'Y-m-d');


### PR DESCRIPTION
## Summary
- Move legend above calendar to prevent it being hidden by the open calendar
- Make Flatpickr display inline so calendar stays open without covering content

## Testing
- `php -l calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3c56e5fb0832e9bdbbcd13194aea1