### PR TITLE
Adjust calendar and summary legends

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -150,12 +150,6 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
             <p>No hay comportamientos guardados. Agregue uno en Configuración.</p>
         <?php else: ?>
             <h2>Configurar calendario</h2>
-            <div class="mb-3">
-                <?php foreach ($behaviorColors as $code => $color): ?>
-                    <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
-                    <?= htmlspecialchars($behaviorSchedules[$code]['name']) ?>&nbsp;
-                <?php endforeach; ?>
-            </div>
             <form method="post" class="mb-3">
                 <div class="row mb-3">
                     <div class="col">
@@ -177,6 +171,13 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
 
                 <button type="submit" class="btn btn-success">Guardar días</button>
             </form>
+
+            <div class="mt-3">
+                <?php foreach ($behaviorColors as $code => $color): ?>
+                    <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
+                    <?= htmlspecialchars($behaviorSchedules[$code]['name']) ?>&nbsp;
+                <?php endforeach; ?>
+            </div>
         <?php endif; ?>
 
         <?php if (!empty($pendingCalls)): ?>
@@ -216,7 +217,6 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
             mode: "multiple",
             dateFormat: "Y-m-d",
             defaultDate: existingDates,
-            inline: true,
             onChange: function(selDates, dateStr, instance) {
                 var dates = selDates.map(function(d) {
                     return instance.formatDate(d, 'Y-m-d');

--- a/index.php
+++ b/index.php
@@ -57,13 +57,13 @@ foreach ($allPeriods as $row) {
 <div class="container">
     <h2 class="d-flex justify-content-center mb-3">Calendario</h2>
     <div id="calendarWrapper" class="d-flex flex-column align-items-center">
-        <input type="text" id="calendar" class="form-control">
-        <div class="mt-3 text-center">
+        <div class="mb-3 text-center">
             <?php foreach ($codeColors as $code => $color): ?>
                 <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
                 <?= htmlspecialchars($codeSchedules[$code]['name']) ?>&nbsp;
             <?php endforeach; ?>
         </div>
+        <input type="text" id="calendar" class="form-control">
     </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- Move configuration legend back below calendar form and remove always-open behaviour.
- Display legend above the inline calendar on the summary page.

## Testing
- `php -l calendar.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3c6a272b0832e8bd9772a1e786d89