### PR TITLE
Add login and user management with encrypted credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Interfaz web en PHP para realizar llamadas mediante la API de Siptize.
 
 1. Abra `config.php` para configurar la API key, la dirección de correo de notificación y los parámetros SMTP (host, puerto, usuario, contraseña y seguridad), realizar llamadas inmediatas o configurar múltiples fechas para cada combinación de extensión y código.
 2. Seleccione los días desde el calendario (puede marcar varios a la vez) y guárdelos; cada día seleccionado se almacenará en la base de datos y aparecerá resaltado al volver a abrir la página.
-3. El Resumen de llamadas y de días programados se visualiza en `index.php`.
+3. El Resumen de llamadas y de días programados se visualiza en `dashboard.php` después de iniciar sesión en `index.php`.
 4. Configure las variables de entorno `DB_HOST`, `DB_NAME`, `DB_USER` y `DB_PASS` o edite los archivos PHP con sus credenciales de MySQL.
 5. Ejecute periódicamente `run_scheduled.php` (por ejemplo, con `cron`) para que las llamadas pendientes se realicen en la fecha indicada. Se enviará un correo de notificación mediante SMTP cuando se ejecute cada llamada.
 

--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit;
+}
+?>

--- a/calendar.php
+++ b/calendar.php
@@ -1,4 +1,5 @@
 <?php
+require __DIR__ . '/auth.php';
 require __DIR__ . '/db.php';
 require __DIR__ . '/schedule_utils.php';
 
@@ -136,10 +137,11 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
         <div class="container-fluid">
             <a class="navbar-brand" href="#">Comportamientos Multivoice</a>
             <div class="navbar-nav">
-                <a class="nav-link" href="index.php">Resumen</a>
+                <a class="nav-link" href="dashboard.php">Resumen</a>
                 <a class="nav-link active" href="calendar.php">Calendario</a>
                 <a class="nav-link" href="calls.php">Ejec. manualmente</a>
                 <a class="nav-link" href="config.php">Configuración</a>
+                <a class="nav-link" href="logout.php">Salir</a>
             </div>
         </div>
     </nav>

--- a/calls.php
+++ b/calls.php
@@ -1,4 +1,5 @@
 <?php
+require __DIR__ . '/auth.php';
 require __DIR__ . '/db.php';
 
 $pdo->exec('CREATE TABLE IF NOT EXISTS calls (
@@ -103,10 +104,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <div class="container-fluid">
         <a class="navbar-brand" href="#">Comportamientos Multivoice</a>
         <div class="navbar-nav">
-            <a class="nav-link" href="index.php">Resumen</a>
+            <a class="nav-link" href="dashboard.php">Resumen</a>
             <a class="nav-link" href="calendar.php">Calendario</a>
             <a class="nav-link active" href="calls.php">Ejec. manualmente</a>
             <a class="nav-link" href="config.php">Configuración</a>
+            <a class="nav-link" href="logout.php">Salir</a>
         </div>
     </div>
 </nav>

--- a/config.php
+++ b/config.php
@@ -1,4 +1,5 @@
 <?php
+require __DIR__ . '/auth.php';
 require __DIR__ . '/db.php';
 require __DIR__ . '/schedule_utils.php';
 // Configuration page with multi-date calendar using Bootstrap and Flatpickr
@@ -36,6 +37,12 @@ try {
     $pdo->exec("ALTER TABLE behaviors ADD COLUMN color VARCHAR(7) DEFAULT '#0d6efd'");
 } catch (PDOException $e) {
 }
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
 
 try {
     $pdo->exec("ALTER TABLE settings ADD COLUMN execution_time VARCHAR(5) DEFAULT '21:00'");
@@ -108,6 +115,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
         $telegramBotId = $bot;
         $telegramChatId = $chat;
+    } elseif ($action === 'save_user') {
+        $username = trim($_POST['username'] ?? '');
+        $password = $_POST['password'] ?? '';
+        if ($username !== '' && $password !== '') {
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            try {
+                $stmt = $pdo->prepare('INSERT INTO users(username, password) VALUES (:username, :password)');
+                $stmt->execute([':username' => $username, ':password' => $hash]);
+                $message = 'Usuario guardado.';
+            } catch (PDOException $e) {
+                $message = 'Nombre de usuario ya existe.';
+            }
+        } else {
+            $message = 'Nombre de usuario y contraseña son obligatorios.';
+        }
+    } elseif ($action === 'delete_user') {
+        $userId = intval($_POST['user_id'] ?? 0);
+        if ($userId) {
+            $pdo->prepare('DELETE FROM users WHERE id = :id')->execute([':id' => $userId]);
+            $message = 'Usuario eliminado.';
+        }
     } elseif ($action === 'save_behavior') {
         $behaviorId = intval($_POST['behavior_id'] ?? 0);
         $behaviorName = trim($_POST['behavior_name'] ?? '');
@@ -147,6 +175,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 }
+$users = $pdo->query('SELECT id, username FROM users ORDER BY username')->fetchAll();
 $behaviors = $pdo->query('SELECT id, name, code, color FROM behaviors ORDER BY name')->fetchAll();
 ?>
 <!DOCTYPE html>
@@ -164,10 +193,11 @@ $behaviors = $pdo->query('SELECT id, name, code, color FROM behaviors ORDER BY n
         <div class="container-fluid">
             <a class="navbar-brand" href="#">Comportamientos Multivoice</a>
             <div class="navbar-nav">
-                <a class="nav-link" href="index.php">Resumen</a>
+                <a class="nav-link" href="dashboard.php">Resumen</a>
                 <a class="nav-link" href="calendar.php">Calendario</a>
                 <a class="nav-link" href="calls.php">Ejec. manualmente</a>
                 <a class="nav-link active" href="config.php">Configuración</a>
+                <a class="nav-link" href="logout.php">Salir</a>
             </div>
         </div>
     </nav>
@@ -216,6 +246,45 @@ $behaviors = $pdo->query('SELECT id, name, code, color FROM behaviors ORDER BY n
             </div>
             <button type="submit" class="btn btn-success">Guardar configuración</button>
         </form>
+        <h2>Usuarios</h2>
+        <form method="post" class="mb-3">
+            <input type="hidden" name="action" value="save_user">
+            <div class="row mb-3">
+                <div class="col-md-6">
+                    <label for="username" class="form-label">Usuario</label>
+                    <input type="text" class="form-control" name="username" id="username" required>
+                </div>
+                <div class="col-md-6">
+                    <label for="password" class="form-label">Contraseña</label>
+                    <input type="password" class="form-control" name="password" id="password" required>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-success">Añadir usuario</button>
+        </form>
+        <?php if ($users): ?>
+            <table class="table table-striped mb-5">
+                <thead>
+                    <tr>
+                        <th>Usuario</th>
+                        <th>Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($users as $u): ?>
+                        <tr>
+                            <td><?= htmlspecialchars($u['username']) ?></td>
+                            <td>
+                                <form method="post" style="display:inline-block" onsubmit="return confirm('¿Eliminar usuario?');">
+                                    <input type="hidden" name="action" value="delete_user">
+                                    <input type="hidden" name="user_id" value="<?= $u['id'] ?>">
+                                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                                </form>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
 
         <h2>Comportamientos</h2>
         <form method="post" class="mb-3">

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,96 @@
+<?php
+require __DIR__ . '/auth.php';
+require __DIR__ . '/db.php';
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS behaviors (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    code VARCHAR(255) NOT NULL UNIQUE,
+    color VARCHAR(7) DEFAULT "#0d6efd"
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+try {
+    $pdo->exec("ALTER TABLE behaviors ADD COLUMN color VARCHAR(7) DEFAULT '#0d6efd'");
+} catch (PDOException $e) {}
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS behavior_days (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    behavior_id INT NOT NULL,
+    day DATE NOT NULL UNIQUE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+$allPeriods = $pdo->query('SELECT bd.day, b.code, b.name, b.color FROM behavior_days bd JOIN behaviors b ON bd.behavior_id = b.id')->fetchAll();
+$codeSchedules = [];
+$codeColors = [];
+foreach ($allPeriods as $row) {
+    $code = $row['code'];
+    if (!isset($codeSchedules[$code])) {
+        $codeSchedules[$code] = ['name' => $row['name'], 'dates' => []];
+        $codeColors[$code] = $row['color'] ?: '#0d6efd';
+    }
+    $codeSchedules[$code]['dates'][] = $row['day'];
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Resumen</title>
+    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="icon" type="image/png" href="favicon.png">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
+    <style>
+    #calendarWrapper .flatpickr-calendar {
+        transform: scale(1.3);
+        transform-origin: top center;
+    }
+    </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark mb-4" style="background-color:#003883">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#">Comportamientos Multivoice</a>
+        <div class="navbar-nav">
+            <a class="nav-link active" href="dashboard.php">Resumen</a>
+            <a class="nav-link" href="calendar.php">Calendario</a>
+            <a class="nav-link" href="calls.php">Ejec. manualmente</a>
+            <a class="nav-link" href="config.php">Configuración</a>
+            <a class="nav-link" href="logout.php">Salir</a>
+        </div>
+    </div>
+</nav>
+<div class="container">
+    <h2 class="d-flex justify-content-center mb-3">Calendario</h2>
+    <div id="calendarWrapper" class="d-flex flex-column align-items-center">
+        <div class="mb-3 text-center">
+            <?php foreach ($codeColors as $code => $color): ?>
+                <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
+                <?= htmlspecialchars($codeSchedules[$code]['name']) ?>&nbsp;
+            <?php endforeach; ?>
+        </div>
+        <input type="text" id="calendar" class="form-control">
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/es.js"></script>
+<script>
+var codeSchedules = <?php echo json_encode($codeSchedules); ?>;
+var codeColors = <?php echo json_encode($codeColors); ?>;
+flatpickr("#calendar", {
+    locale: "es",
+    inline: true,
+    clickOpens: false,
+    onDayCreate: function(dObj, dStr, fp, dayElem) {
+        var date = fp.formatDate(dayElem.dateObj, "Y-m-d");
+        Object.keys(codeSchedules).forEach(function(code) {
+            if (codeSchedules[code].dates.indexOf(date) !== -1) {
+                dayElem.style.backgroundColor = codeColors[code];
+                dayElem.style.color = '#fff';
+            }
+        });
+    }
+});
+document.getElementById('calendar').style.display = 'none';
+</script>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -1,94 +1,65 @@
 <?php
 require __DIR__ . '/db.php';
+session_start();
 
-$pdo->exec('CREATE TABLE IF NOT EXISTS behaviors (
+$pdo->exec('CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(255) NOT NULL,
-    code VARCHAR(255) NOT NULL UNIQUE,
-    color VARCHAR(7) DEFAULT "#0d6efd"
+    username VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
-try {
-    $pdo->exec("ALTER TABLE behaviors ADD COLUMN color VARCHAR(7) DEFAULT '#0d6efd'");
-} catch (PDOException $e) {}
 
-$pdo->exec('CREATE TABLE IF NOT EXISTS behavior_days (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    behavior_id INT NOT NULL,
-    day DATE NOT NULL UNIQUE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
-$allPeriods = $pdo->query('SELECT bd.day, b.code, b.name, b.color FROM behavior_days bd JOIN behaviors b ON bd.behavior_id = b.id')->fetchAll();
-$codeSchedules = [];
-$codeColors = [];
-foreach ($allPeriods as $row) {
-    $code = $row['code'];
-    if (!isset($codeSchedules[$code])) {
-        $codeSchedules[$code] = ['name' => $row['name'], 'dates' => []];
-        $codeColors[$code] = $row['color'] ?: '#0d6efd';
+if (isset($_SESSION['user_id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+    if ($username !== '' && $password !== '') {
+        $stmt = $pdo->prepare('SELECT id, password FROM users WHERE username = :username');
+        $stmt->execute([':username' => $username]);
+        $user = $stmt->fetch();
+        if ($user && password_verify($password, $user['password'])) {
+            $_SESSION['user_id'] = $user['id'];
+            $_SESSION['username'] = $username;
+            header('Location: dashboard.php');
+            exit;
+        } else {
+            $message = 'Usuario o contraseña incorrectos.';
+        }
+    } else {
+        $message = 'Nombre de usuario y contraseña son obligatorios.';
     }
-    $codeSchedules[$code]['dates'][] = $row['day'];
 }
 ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Resumen</title>
-    <link rel="icon" type="image/png" href="favicon.png">
+    <title>Login</title>
     <link rel="icon" type="image/png" href="favicon.png">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
-    <style>
-    #calendarWrapper .flatpickr-calendar {
-        transform: scale(1.3);
-        transform-origin: top center;
-    }
-    </style>
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark mb-4" style="background-color:#003883">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="#">Comportamientos Multivoice</a>
-        <div class="navbar-nav">
-            <a class="nav-link active" href="index.php">Resumen</a>
-            <a class="nav-link" href="calendar.php">Calendario</a>
-            <a class="nav-link" href="calls.php">Ejec. manualmente</a>
-            <a class="nav-link" href="config.php">Configuración</a>
+<div class="container mt-5" style="max-width: 400px;">
+    <h2 class="mb-4 text-center">Iniciar sesión</h2>
+    <?php if ($message): ?>
+        <div class="alert alert-danger"><?= htmlspecialchars($message) ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <div class="mb-3">
+            <label for="username" class="form-label">Usuario</label>
+            <input type="text" class="form-control" name="username" id="username" required>
         </div>
-    </div>
-</nav>
-<div class="container">
-    <h2 class="d-flex justify-content-center mb-3">Calendario</h2>
-    <div id="calendarWrapper" class="d-flex flex-column align-items-center">
-        <div class="mb-3 text-center">
-            <?php foreach ($codeColors as $code => $color): ?>
-                <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
-                <?= htmlspecialchars($codeSchedules[$code]['name']) ?>&nbsp;
-            <?php endforeach; ?>
+        <div class="mb-3">
+            <label for="password" class="form-label">Contraseña</label>
+            <input type="password" class="form-control" name="password" id="password" required>
         </div>
-        <input type="text" id="calendar" class="form-control">
-    </div>
+        <button type="submit" class="btn btn-primary w-100">Entrar</button>
+    </form>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-<script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/es.js"></script>
-<script>
-var codeSchedules = <?php echo json_encode($codeSchedules); ?>;
-var codeColors = <?php echo json_encode($codeColors); ?>;
-flatpickr("#calendar", {
-    locale: "es",
-    inline: true,
-    clickOpens: false,
-    onDayCreate: function(dObj, dStr, fp, dayElem) {
-        var date = fp.formatDate(dayElem.dateObj, "Y-m-d");
-        Object.keys(codeSchedules).forEach(function(code) {
-            if (codeSchedules[code].dates.indexOf(date) !== -1) {
-                dayElem.style.backgroundColor = codeColors[code];
-                dayElem.style.color = '#fff';
-            }
-        });
-    }
-});
-document.getElementById('calendar').style.display = 'none';
-</script>
 </body>
 </html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_destroy();
+header('Location: index.php');
+exit;
+?>


### PR DESCRIPTION
## Summary
- Introduce session-based login at `index.php`, storing user credentials hashed in a `users` table.
- Require authentication across the app via a shared `auth.php` guard and add logout handling.
- Expand `config.php` with a new **Usuarios** section to create and remove users beneath general settings.

## Testing
- `php -l index.php`
- `php -l dashboard.php`
- `php -l calendar.php`
- `php -l calls.php`
- `php -l config.php`
- `php -l auth.php`
- `php -l logout.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7af3bedc4832eacc12eed60ff7a56