### PR TITLE
Avoid scheduling past behavior changes

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -119,7 +119,7 @@ foreach ($allPeriods as $row) {
 // Fetch pending scheduled calls with behavior names
 $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.name AS behavior_name '
     . 'FROM scheduled_calls sc JOIN behaviors b ON sc.number = b.code '
-    . 'WHERE sc.executed_at IS NULL ORDER BY sc.scheduled_at')
+    . 'WHERE sc.executed_at IS NULL AND sc.scheduled_at >= NOW() ORDER BY sc.scheduled_at')
     ->fetchAll();
 ?>
 <!DOCTYPE html>

--- a/schedule_utils.php
+++ b/schedule_utils.php
@@ -26,6 +26,7 @@ function rebuildScheduledCalls(PDO $pdo, string $defaultExtension, string $execu
 
     $prevDay = null;
     $prevCode = null;
+    $now = new DateTime();
 
     foreach ($rows as $row) {
         $day = new DateTime($row['day']);
@@ -45,12 +46,15 @@ function rebuildScheduledCalls(PDO $pdo, string $defaultExtension, string $execu
             } else {
                 $schedDay = $day;
             }
-            $pdo->prepare('INSERT INTO scheduled_calls(extension, number, scheduled_at) VALUES (:ext, :num, :sched)')
-                ->execute([
-                    ':ext' => $defaultExtension,
-                    ':num' => $code,
-                    ':sched' => $schedDay->format('Y-m-d') . ' ' . $executionTime . ':00'
-                ]);
+            $scheduledAt = $schedDay->format('Y-m-d') . ' ' . $executionTime . ':00';
+            if (new DateTime($scheduledAt) >= $now) {
+                $pdo->prepare('INSERT INTO scheduled_calls(extension, number, scheduled_at) VALUES (:ext, :num, :sched)')
+                    ->execute([
+                        ':ext' => $defaultExtension,
+                        ':num' => $code,
+                        ':sched' => $scheduledAt
+                    ]);
+            }
         }
         $prevDay = $day;
         $prevCode = $code;


### PR DESCRIPTION
## Summary
- Skip scheduling calls when the scheduled execution date is in the past
- Show only upcoming scheduled calls on the calendar

## Testing
- `php -l schedule_utils.php`
- `php -l calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7ce157e80832e8a7174bd78a32e84