### PR TITLE
Ajusta el diseño del calendario

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -154,6 +154,17 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
             border-radius: 4px;
             pointer-events: none;
         }
+
+        .flatpickr-calendar.inline {
+            width: 100%;
+            max-width: 420px;
+        }
+
+        .flatpickr-calendar.inline .flatpickr-day {
+            height: 2.75rem;
+            line-height: 2.75rem;
+            font-size: 1.05rem;
+        }
     </style>
 </head>
 
@@ -183,35 +194,31 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
                     <h2>Configurar calendario</h2>
                     <div class="row mb-3">
                         <form method="post" class="mb-3">
-
-                            <div class="row mb-3">
+                            <div class="row g-3">
                                 <div class="col-md-4">
-
-
                                     <label for="behavior" class="form-label">Comportamiento</label>
                                     <select class="form-select" name="behavior" id="behavior" onchange="location='calendar.php?behavior='+this.value;">
                                         <?php foreach ($behaviors as $b): ?>
                                             <option value="<?= $b['id'] ?>" <?= $b['id'] == $behaviorId ? 'selected' : '' ?>><?= htmlspecialchars($b['name']) ?></option>
                                         <?php endforeach; ?>
                                     </select>
-
-
                                 </div>
                                 <div class="col-md-8">
                                     <label for="datePicker" class="form-label">Días</label>
                                     <input type="text" id="datePicker" class="form-control" style="display:none;">
                                     <input type="hidden" name="dates" id="dates">
                                 </div>
-
-
-                                <div class="row mb-3">
-                                    <div class="mt-3">
+                                <div class="col-12">
+                                    <p class="mb-1 text-uppercase text-muted small fw-semibold">Leyenda</p>
+                                    <div class="d-flex flex-wrap align-items-center gap-2">
                                         <?php foreach ($behaviorColors as $code => $color): ?>
                                             <span class="badge" style="background-color: <?= $color ?>;">&nbsp;</span>
-                                            <?= htmlspecialchars($behaviorSchedules[$code]['name']) ?>&nbsp;
+                                            <span class="me-3"><?= htmlspecialchars($behaviorSchedules[$code]['name']) ?></span>
                                         <?php endforeach; ?>
-                                        <button type="submit" class="btn btn-success">Guardar días</button>
                                     </div>
+                                </div>
+                                <div class="col-12">
+                                    <button type="submit" class="btn btn-success">Guardar días</button>
                                 </div>
                             </div>
                         </form>


### PR DESCRIPTION
## Summary
- reordena el formulario para mostrar la leyenda bajo el selector de comportamiento y el botón de guardado a continuación
- ajusta el estilo del calendario inline para que se muestre ligeramente más grande

## Testing
- php -l calendar.php

------
https://chatgpt.com/codex/tasks/task_e_69007984e768832e8ac637187b7e556c